### PR TITLE
Nova theme basic colors

### DIFF
--- a/doom-nova-theme.el
+++ b/doom-nova-theme.el
@@ -40,7 +40,7 @@ determine the exact padding."
    (highlight      cyan)
    (vertical-bar   (doom-darken dark-grey 0.2))
    (current-line   (doom-darken bg-alt 0.05))
-   (selection      (doom-lighten highlight 0.3))
+   (selection      (doom-lighten highlight 0.6))
    (builtin        blue)
    (comments       grey)
    (doc-comments   (doom-lighten grey 0.1))
@@ -95,8 +95,16 @@ determine the exact padding."
    ;; linum
    (linum :foreground grey :background bg :bold nil :distant-foreground nil)
    (doom-linum-highlight :foreground highlight :background bg :bold nil :distant-foreground nil)
-   (cursor :background highlight))
+   (cursor :background highlight)
 
+   ;; helm
+   (helm-selection :foreground dark-grey :background selection)
+   (helm-match     :foreground highlight)
+
+   ;; company
+   (company-tooltip-selection  :background selection :foreground dark-grey)
+
+   )
 
   ;; --- variables --------------------------
   ;; ()

--- a/doom-nova-theme.el
+++ b/doom-nova-theme.el
@@ -61,7 +61,6 @@ determine the exact padding."
    (vc-added       green)
    (vc-deleted     red)
 
-
    ;; custom categories
    (modeline-bg     (doom-darken bg-alt 0.3))
    (modeline-bg-alt (doom-darken bg 0.2))
@@ -91,7 +90,13 @@ determine the exact padding."
     :box (if modeline-pad `(:line-width ,modeline-pad :color ,modeline-bg)))
    (mode-line-inactive
     :background modeline-bg-alt :foreground modeline-fg-alt
-    :box (if modeline-pad `(:line-width ,modeline-pad :color ,modeline-bg-alt))))
+    :box (if modeline-pad `(:line-width ,modeline-pad :color ,modeline-bg-alt)))
+
+   ;; linum
+   (linum :foreground grey :background bg :bold nil :distant-foreground nil)
+   (doom-linum-highlight :foreground highlight :background bg :bold nil :distant-foreground nil)
+   (cursor :background highlight))
+
 
   ;; --- variables --------------------------
   ;; ()
@@ -99,4 +104,3 @@ determine the exact padding."
 
 (provide 'doom-nova-theme)
 ;;; doom-nova-theme.el ends here
-

--- a/doom-nova-theme.el
+++ b/doom-nova-theme.el
@@ -40,11 +40,11 @@ determine the exact padding."
    (highlight      blue)
    (vertical-bar   (doom-darken dark-grey 0.2))
    (current-line   (doom-darken bg-alt 0.05))
-   (selection      (doom-lighten bg 0.1))
+   (selection      (doom-lighten highlight 0.3))
    (builtin        blue)
    (comments       grey)
    (doc-comments   (doom-lighten grey 0.1))
-   (constants      orange)
+   (constants      highlight)
    (functions      blue)
    (keywords       violet)
    (methods        blue)
@@ -52,7 +52,7 @@ determine the exact padding."
    (type           yellow)
    (strings        green)
    (variables      red)
-   (numbers        orange)
+   (numbers        highlight)
    (region         selection)
    (error          red)
    (warning        yellow)
@@ -73,7 +73,7 @@ determine the exact padding."
         4))))
 
   ;; --- faces ------------------------------
-  ((doom-modeline-buffer-path       :foreground violet :bold bold)
+  ((doom-modeline-buffer-path       :foreground violet :bold nil)
    (doom-modeline-buffer-major-mode :inherit 'doom-modeline-buffer-path)
 
    ;; rainbow-delimiters

--- a/doom-nova-theme.el
+++ b/doom-nova-theme.el
@@ -1,0 +1,102 @@
+;;; doom-nova-theme.el
+(require 'doom-themes)
+
+(defgroup doom-nova-theme nil
+  "Options for doom-themes"
+  :group 'doom-themes)
+
+(defcustom doom-nova-padded-modeline nil
+  "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
+determine the exact padding."
+  :group 'doom-nova-theme
+  :type '(or integer boolean))
+
+(def-doom-theme doom-nova
+  "A light theme inspired by Atom One Light."
+
+  ;; name      gui
+  ((bg         "#3f4c55")
+   (bg-alt     "#556873")
+   (fg         "#c5c8c6") ;; TODO set correct color
+   (fg-alt     (doom-darken fg 0.6)) ;; TODO set correct color
+   (black      "#0d0f11") ;; TODO set correct color
+   (light-grey "#E6EEF3")
+   (grey       (doom-darken light-grey 0.4))
+   (dark-grey  (doom-darken grey 0.7))
+   (white      "#ffffff")
+   (red        "#DF8C8C")
+   (orange     "#F2C38F")
+   (yellow     "#DADA93")
+   (green      "#A8CE93")
+   (blue       "#83AFE5")
+   (dark-blue  (doom-darken blue 0.7))
+   (teal       blue)
+   (magenta    (doom-lighten "#b294bb" 0.3)) ; FIXME TODO set correct color
+   (violet     "#9A93E1")
+   (cyan       "#7FC1CA")
+   (dark-cyan  (doom-darken cyan 0.4))
+
+   ;; face categories
+   (highlight      dark-blue)
+   (vertical-bar   (doom-darken dark-grey 0.2))
+   (current-line   (doom-darken bg-alt 0.05))
+   (selection      (doom-lighten bg 0.1))
+   (builtin        blue)
+   (comments       grey)
+   (doc-comments   (doom-lighten grey 0.1))
+   (constants      orange)
+   (functions      blue)
+   (keywords       violet)
+   (methods        blue)
+   (operators      fg)
+   (type           yellow)
+   (strings        green)
+   (variables      red)
+   (numbers        orange)
+   (region         selection)
+   (error          red)
+   (warning        yellow)
+   (success        green)
+   (vc-modified    fg-alt)
+   (vc-added       green)
+   (vc-deleted     red)
+
+
+   ;; custom categories
+   (modeline-bg     (doom-darken bg-alt 0.3))
+   (modeline-bg-alt (doom-darken bg 0.2))
+   (modeline-fg     blue)
+   (modeline-fg-alt grey)
+   (modeline-pad
+    (when doom-nova-padded-modeline
+      (if (integerp doom-nova-padded-modeline)
+          doom-nova-padded-modeline
+        4))))
+
+  ;; --- faces ------------------------------
+  ((doom-modeline-buffer-path       :foreground violet :bold bold)
+   (doom-modeline-buffer-major-mode :inherit 'doom-modeline-buffer-path)
+
+   ;; rainbow-delimiters
+   (rainbow-delimiters-depth-1-face :foreground violet)
+   (rainbow-delimiters-depth-2-face :foreground blue)
+   (rainbow-delimiters-depth-3-face :foreground orange)
+   (rainbow-delimiters-depth-4-face :foreground green)
+   (rainbow-delimiters-depth-5-face :foreground magenta)
+   (rainbow-delimiters-depth-6-face :foreground yellow)
+   (rainbow-delimiters-depth-7-face :foreground teal)
+
+   (mode-line
+    :background modeline-bg :foreground modeline-fg
+    :box (if modeline-pad `(:line-width ,modeline-pad :color ,modeline-bg)))
+   (mode-line-inactive
+    :background modeline-bg-alt :foreground modeline-fg-alt
+    :box (if modeline-pad `(:line-width ,modeline-pad :color ,modeline-bg-alt))))
+
+  ;; --- variables --------------------------
+  ;; ()
+  )
+
+(provide 'doom-nova-theme)
+;;; doom-nova-theme.el ends here
+

--- a/doom-nova-theme.el
+++ b/doom-nova-theme.el
@@ -37,7 +37,7 @@ determine the exact padding."
    (dark-cyan  (doom-darken cyan 0.4))
 
    ;; face categories
-   (highlight      blue)
+   (highlight      cyan)
    (vertical-bar   (doom-darken dark-grey 0.2))
    (current-line   (doom-darken bg-alt 0.05))
    (selection      (doom-lighten highlight 0.3))
@@ -50,7 +50,7 @@ determine the exact padding."
    (methods        blue)
    (operators      fg)
    (type           yellow)
-   (strings        green)
+   (strings        cyan)
    (variables      red)
    (numbers        highlight)
    (region         selection)

--- a/doom-nova-theme.el
+++ b/doom-nova-theme.el
@@ -37,7 +37,7 @@ determine the exact padding."
    (dark-cyan  (doom-darken cyan 0.4))
 
    ;; face categories
-   (highlight      dark-blue)
+   (highlight      blue)
    (vertical-bar   (doom-darken dark-grey 0.2))
    (current-line   (doom-darken bg-alt 0.05))
    (selection      (doom-lighten bg 0.1))


### PR DESCRIPTION
This PR adds the basic color scheme for new theme based on [Nova](https://trevordmiller.com/projects/nova) as discussed in #60.

I've marked some of the lines with a **TODO set correct color** where I don't know what color to use. I've used this values as a guide for creating the file https://github.com/trevordmiller/nova-colors/blob/master/src/index.js.

This is the WIP result, which doesn't look very good... 🤔 

![image](https://cloud.githubusercontent.com/assets/1090272/26237512/bcd5bd88-3c75-11e7-91bc-c05adf193589.png)

I hope it helps as a starting point for creating another awesome doom's version 🤘 