### PR TITLE
[ledger-mode] Nicer active transaction background

### DIFF
--- a/doom-themes-common.el
+++ b/doom-themes-common.el
@@ -692,7 +692,7 @@
     (ledger-font-posting-account-face :foreground base8)
     (ledger-font-payee-cleared-face :foreground violet :bold t :height 1.2)
     (ledger-font-payee-uncleared-face :foreground base5 :bold t :height 1.2)
-    (ledger-font-xact-highlight-face :background base5)
+    (ledger-font-xact-highlight-face :background base0)
 
     ;; makefile-*-mode
     (makefile-targets :foreground blue)


### PR DESCRIPTION
Brings back dark background for transactions under the cursor. In one of the refactoring it got brighter.

![test dat 2017-07-01 16-29-42](https://user-images.githubusercontent.com/138331/27762908-7c154bc0-5e7a-11e7-9865-c72b5d3a5c91.png)
