### PR TITLE
add support for built in line number highlight face

### DIFF
--- a/doom-themes-common.el
+++ b/doom-themes-common.el
@@ -411,6 +411,9 @@
     (jabber-roster-user-online     :foreground green :bold bold)
     (jabber-roster-user-xa         :foreground cyan)
 
+    ;; line numbers (built-in)
+    (line-number-current-line (&inherit linum-highlight-face))
+
     ;; linum-relative
     (linum-relative-current-face (&inherit linum-highlight-face))
 


### PR DESCRIPTION
This commit add supports for the built in line number highlighting support that was just merged into Emacs master.

Here's what it looks like:

![line numbers](http://drop.bryan.sh/EQawbhYv1r.png)

You can find more detail on the new line number faces here: http://git.savannah.gnu.org/cgit/emacs.git/tree/etc/NEWS#n436