### PR TITLE
Fix: ansi-color-names-vector: vector -> vconcat

### DIFF
--- a/doom-themes-common.el
+++ b/doom-themes-common.el
@@ -797,7 +797,7 @@
 
 (defconst doom-themes-common-vars
   '((ansi-color-names-vector
-     (vector (mapcar #'doom-color '(base0 red green yellow blue magenta cyan base8))))
+     (vconcat (mapcar #'doom-color '(base0 red green yellow blue magenta cyan base8))))
 
     (fci-rule-color (doom-color 'base5))
 


### PR DESCRIPTION
ansi-color expects this type of vector ["color1" "color2" "color3" ...]

(vector sequence) returns [(seq uen ce)] while
(vconcat (sequence)) returns [seq uen ce]