### PR TITLE
Change vc-modified to orange

### DIFF
--- a/themes/doom-one-theme.el
+++ b/themes/doom-one-theme.el
@@ -80,7 +80,7 @@ determine the exact padding."
    (error          red)
    (warning        yellow)
    (success        green)
-   (vc-modified    base5)
+   (vc-modified    orange)
    (vc-added       green)
    (vc-deleted     red)
 


### PR DESCRIPTION
Atom uses yellow which is too similar to green, but orange is distinct and looks better than gray.