### PR TITLE
make it clear when visualize (in visual mode) markdown code block

### DIFF
--- a/themes/doom-one-light-theme.el
+++ b/themes/doom-one-light-theme.el
@@ -151,7 +151,8 @@ determine the exact padding."
    ;; markdown-mode
    (markdown-markup-face :foreground base5)
    (markdown-header-face :inherit 'bold :foreground red)
-   (markdown-code-face :background (doom-darken base3 0.05))
+   (markdown-code-face :background base3)
+   (mmm-default-submode-face :background base3)
 
    ;; org-mode
    (org-block            :background bg)


### PR DESCRIPTION
Cannot see the selected lines of code blocks in markdown mode. I make this change to visualize it.
![image](https://user-images.githubusercontent.com/16655096/30227390-8b90c5a8-94a7-11e7-9506-f9982c7569d1.png)
