### PR TITLE
Face tweaks for markdown and org block, helm, web-mode, wgrep

### DIFF
--- a/themes/doom-one-light-theme.el
+++ b/themes/doom-one-light-theme.el
@@ -158,11 +158,11 @@ determine the exact padding."
    ;; markdown-mode
    (markdown-markup-face :foreground base5)
    (markdown-header-face :inherit 'bold :foreground red)
-   (markdown-code-face :background base3)
-   (mmm-default-submode-face :background base3)
+   (markdown-code-face :background base1)
+   (mmm-default-submode-face :background base1)
 
    ;; org-mode
-   (org-block            :background bg)
+   (org-block            :background base1)
    (org-block-begin-line :foreground fg :slant 'italic)
    (org-level-1          :background bg :foreground red :bold t :height 1.2)
    (org-level-3          :bold 'bold :foreground violet :height 1.1)

--- a/themes/doom-one-light-theme.el
+++ b/themes/doom-one-light-theme.el
@@ -167,6 +167,15 @@ determine the exact padding."
    (org-level-1          :background bg :foreground red :bold t :height 1.2)
    (org-level-3          :bold 'bold :foreground violet :height 1.1)
    (org-ellipsis         :underline nil :background bg :foreground red)
+
+   ;; helm
+   (helm-candidate-number :background blue :foreground fg)
+
+   ;; web-mode
+   (web-mode-current-element-highlight-face :backgound blue :foreground fg)
+
+   ;; wgrep
+   (wgrep-face :background base1)
    )
 
   ;; --- extra variables ---------------------


### PR DESCRIPTION
Base3 is too dark for markdown, so I put base1 here. While for org block, I think it should be consistent with markdown block.

This is how it looks in doom emacs with `solaire-mode`.

![jietu20171113-181745 2x](https://user-images.githubusercontent.com/16655096/32754993-39e36c8c-c8a1-11e7-81f5-2eeda26dac64.jpg)

I tweaked some faces with black background as default. It looks better now.

Thanks!