### PR TITLE
Add ediff faces and org quote background

### DIFF
--- a/themes/doom-one-light-theme.el
+++ b/themes/doom-one-light-theme.el
@@ -177,6 +177,12 @@ determine the exact padding."
 
    ;; wgrep
    (wgrep-face :background base1)
+
+   ;; ediff
+   (ediff-current-diff-A        :foreground red   :background (doom-lighten red 0.8))
+   (ediff-current-diff-B        :foreground green :background (doom-lighten green 0.8))
+   (ediff-current-diff-C        :foreground blue  :background (doom-lighten blue 0.8))
+   (ediff-current-diff-Ancestor :foreground teal  :background (doom-lighten teal 0.8))
    )
 
   ;; --- extra variables ---------------------

--- a/themes/doom-one-light-theme.el
+++ b/themes/doom-one-light-theme.el
@@ -164,9 +164,10 @@ determine the exact padding."
    ;; org-mode
    (org-block            :background base1)
    (org-block-begin-line :foreground fg :slant 'italic)
-   (org-level-1          :background bg :foreground red :bold t :height 1.2)
-   (org-level-3          :bold 'bold :foreground violet :height 1.1)
-   (org-ellipsis         :underline nil :background bg :foreground red)
+   (org-level-1          :background bg :foreground red    :bold t :height 1.2)
+   (org-level-3          :bold 'bold    :foreground violet :height 1.1)
+   (org-ellipsis         :underline nil :background bg     :foreground red)
+   (org-quote            :background base1)
 
    ;; helm
    (helm-candidate-number :background blue :foreground bg)


### PR DESCRIPTION
Just a slight modification. I use Spacemacs and its built-in theme has differences between `ediff-current-diff-*` faces. So I modified them in doom-one-light theme.

Here are what these faces look like.
![image](https://user-images.githubusercontent.com/16655096/33360121-449f809c-d4a0-11e7-97ad-e32edad12c3c.png)
