### PR TITLE
Change vertical-bar so that window-divider stands out.

### DIFF
--- a/themes/doom-molokai-theme.el
+++ b/themes/doom-molokai-theme.el
@@ -51,7 +51,7 @@ determine the exact padding."
 
    ;; face categories
    (highlight      orange)
-   (vertical-bar   base2)
+   (vertical-bar   (doom-lighten bg 0.1))
    (selection      base0)
    (builtin        orange)
    (comments       (if doom-molokai-brighter-comments violet base5))

--- a/themes/doom-nova-theme.el
+++ b/themes/doom-nova-theme.el
@@ -50,7 +50,7 @@ determine the exact padding."
 
    ;; face categories
    (highlight      cyan)
-   (vertical-bar   (doom-lighten bg-alt 0.1))
+   (vertical-bar   (doom-lighten bg 0.1))
    (selection      (doom-lighten highlight 0.6))
    (builtin        blue)
    (comments       grey)

--- a/themes/doom-one-light-theme.el
+++ b/themes/doom-one-light-theme.el
@@ -62,7 +62,7 @@ determine the exact padding."
 
    ;; face categories -- required for all themes
    (highlight      blue)
-   (vertical-bar   base2)
+   (vertical-bar   (doom-darken base2 0.1))
    (selection      dark-blue)
    (builtin        magenta)
    (comments       (if doom-one-light-brighter-comments cyan base4))

--- a/themes/doom-one-theme.el
+++ b/themes/doom-one-theme.el
@@ -62,7 +62,7 @@ determine the exact padding."
 
    ;; face categories -- required for all themes
    (highlight      blue)
-   (vertical-bar   base1)
+   (vertical-bar   (doom-lighten bg 0.1))
    (selection      dark-blue)
    (builtin        magenta)
    (comments       (if doom-one-brighter-comments dark-cyan base5))

--- a/themes/doom-peacock-theme.el
+++ b/themes/doom-peacock-theme.el
@@ -63,7 +63,7 @@ determine the exact padding."
 
    ;; face categories -- required for all themes
    (highlight      red)
-   (vertical-bar   bg-alt)
+   (vertical-bar   (doom-lighten bg 0.1))
    (selection      coral-popup)
    (builtin        red)
    (comments       (if doom-peacock-brighter-comments dark-cyan base5)) ;; TODO

--- a/themes/doom-solarized-light-theme.el
+++ b/themes/doom-solarized-light-theme.el
@@ -62,7 +62,7 @@ determine the exact padding."
 
    ;; face categories -- required for all themes
    (highlight      blue)
-   (vertical-bar   base1)
+   (vertical-bar   (doom-darken base1 0.1))
    (selection      dark-blue)
    (builtin        magenta)
    (comments       (if doom-soliarized-light-brighter-comments dark-cyan base5))

--- a/themes/doom-spacegrey-theme.el
+++ b/themes/doom-spacegrey-theme.el
@@ -61,7 +61,7 @@ determine the exact padding."
 
    ;; face categories -- required for all themes
    (highlight      orange)
-   (vertical-bar   (doom-darken bg-alt 0.1))
+   (vertical-bar   (doom-lighten bg 0.1))
    (selection      base4)
    (builtin        orange)
    (comments       base5)

--- a/themes/doom-tomorrow-night-theme.el
+++ b/themes/doom-tomorrow-night-theme.el
@@ -44,7 +44,7 @@ determine the exact padding."
 
    ;; face categories
    (highlight      dark-blue)
-   (vertical-bar   base1)
+   (vertical-bar   (doom-lighten bg 0.1))
    (selection      (doom-lighten bg 0.1))
    (builtin        blue)
    (comments       grey)

--- a/themes/doom-vibrant-theme.el
+++ b/themes/doom-vibrant-theme.el
@@ -63,7 +63,7 @@ determine the exact padding."
 
    ;; face categories
    (highlight      blue)
-   (vertical-bar   (doom-darken bg 0.15))
+   (vertical-bar   (doom-lighten bg 0.15))
    (selection      dark-blue)
    (builtin        magenta)
    (comments       (if doom-vibrant-brighter-comments dark-cyan base5))


### PR DESCRIPTION
`vertical-bar` was set to a color too close to the background, making it essentially invisible in most dark themes. It seems like `(doom-lighten bg 0.1)` is a good choice for dark themes, and correspondingly `(doom-darken bg 0.1)` for light themes.