### PR TITLE
Fix fg/bg and modeline-bright

### DIFF
--- a/themes/doom-city-lights-theme.el
+++ b/themes/doom-city-lights-theme.el
@@ -58,6 +58,7 @@ determine the exact padding."
    (magenta    '("#E27E8D" "#c678dd" "magenta"      ))
    (violet     '("#B62D65" "#a9a1e1" "brightmagenta"))
    (cyan       '("#70E1E8" "#46D9FF" "brightcyan"   ))
+   (dark-cyan  '("#41858C" "#46D9FF" "brightcyan"   ))
 
    ;; face categories -- required for all themes
    (highlight      blue)

--- a/themes/doom-city-lights-theme.el
+++ b/themes/doom-city-lights-theme.el
@@ -58,7 +58,7 @@ determine the exact padding."
    (magenta    '("#E27E8D" "#c678dd" "magenta"      ))
    (violet     '("#B62D65" "#a9a1e1" "brightmagenta"))
    (cyan       '("#70E1E8" "#46D9FF" "brightcyan"   ))
-   (dark-cyan  '("#41858C" "#46D9FF" "brightcyan"   ))
+   (dark-cyan  '("#41858C" "#5699AF" "cyan"   ))
 
    ;; face categories -- required for all themes
    (highlight      blue)

--- a/themes/doom-city-lights-theme.el
+++ b/themes/doom-city-lights-theme.el
@@ -1,35 +1,35 @@
-;;; doom-citylights-theme.el --- inspired by Atom One Dark
+;;; doom-city-lights-theme.el --- inspired by Atom City Lights
 (require 'doom-themes)
 
 ;;
-(defgroup doom-citylights-theme nil
+(defgroup doom-city-lights-theme nil
   "Options for doom-themes"
   :group 'doom-themes)
 
-(defcustom doom-citylights-brighter-modeline nil
+(defcustom doom-city-lights-brighter-modeline nil
   "If non-nil, more vivid colors will be used to style the mode-line."
-  :group 'doom-citylights-theme
+  :group 'doom-city-lights-theme
   :type 'boolean)
 
-(defcustom doom-citylights-brighter-comments nil
+(defcustom doom-city-lights-brighter-comments nil
   "If non-nil, comments will be highlighted in more vivid colors."
-  :group 'doom-citylights-theme
+  :group 'doom-city-lights-theme
   :type 'boolean)
 
-(defcustom doom-citylights-comment-bg doom-citylights-brighter-comments
+(defcustom doom-city-lights-comment-bg doom-city-lights-brighter-comments
   "If non-nil, comments will have a subtle, darker background. Enhancing their
 legibility."
-  :group 'doom-citylights-theme
+  :group 'doom-city-lights-theme
   :type 'boolean)
 
-(defcustom doom-citylights-padded-modeline nil
+(defcustom doom-city-lights-padded-modeline nil
   "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
 determine the exact padding."
-  :group 'doom-citylights-theme
+  :group 'doom-city-lights-theme
   :type '(or integer boolean))
 
 ;;
-(def-doom-theme doom-citylights
+(def-doom-theme doom-city-lights
   "A dark theme inspired by Atom One Dark"
 
   ;; name        default   256       16
@@ -64,8 +64,8 @@ determine the exact padding."
    (vertical-bar   (doom-darken base1 0.5))
    (selection      dark-blue)
    (builtin        blue)
-   (comments       (if doom-citylights-brighter-comments dark-cyan base5))
-   (doc-comments   (doom-lighten (if doom-citylights-brighter-comments dark-cyan base5) 0.25))
+   (comments       (if doom-city-lights-brighter-comments dark-cyan base5))
+   (doc-comments   (doom-lighten (if doom-city-lights-brighter-comments dark-cyan base5) 0.25))
    (constants      red)
    (functions      teal)
    (keywords       blue)
@@ -85,10 +85,10 @@ determine the exact padding."
 
    ;; custom categories
    (hidden     `(,(car bg) "black" "black"))
-   (-modeline-bright doom-citylights-brighter-modeline)
+   (-modeline-bright doom-city-lights-brighter-modeline)
    (-modeline-pad
-    (when doom-citylights-padded-modeline
-      (if (integerp doom-citylights-padded-modeline) doom-citylights-padded-modeline 4)))
+    (when doom-city-lights-padded-modeline
+      (if (integerp doom-city-lights-padded-modeline) doom-city-lights-padded-modeline 4)))
 
    (modeline-fg     nil)
    (modeline-fg-alt base5)
@@ -113,7 +113,7 @@ determine the exact padding."
 
    (font-lock-comment-face
     :foreground comments
-    :background (if doom-citylights-comment-bg (doom-lighten bg 0.05)))
+    :background (if doom-city-lights-comment-bg (doom-lighten bg 0.05)))
    (font-lock-doc-face
     :inherit 'font-lock-comment-face
     :foreground doc-comments)
@@ -158,4 +158,4 @@ determine the exact padding."
   ;; ()
   )
 
-;;; doom-citylights-theme.el ends here
+;;; doom-city-lights-theme.el ends here

--- a/themes/doom-city-lights-theme.el
+++ b/themes/doom-city-lights-theme.el
@@ -75,7 +75,7 @@ determine the exact padding."
    (strings        base7)
    (variables      base8)
    (numbers        magenta)
-   (region         base2)
+   (region         base3)
    (error          red)
    (warning        yellow)
    (success        green)

--- a/themes/doom-citylights-theme.el
+++ b/themes/doom-citylights-theme.el
@@ -33,19 +33,19 @@ determine the exact padding."
   "A dark theme inspired by Atom One Dark"
 
   ;; name        default   256       16
-  ((bg         '("#181E24" nil       nil            ))
-   (bg-alt     '("#1D252C" nil       nil            ))
-   (base0      '("#11171D" "black"   "black"        ))
-   (base1      '("#212930" "#1e1e1e" "brightblack"  ))
-   (base2      '("#333F4A" "#2e2e2e" "brightblack"  ))
-   (base3      '("#3A4855" "#262626" "brightblack"  ))
-   (base4      '("#41505E" "#3f3f3f" "brightblack"  ))
-   (base5      '("#5F7487" "#525252" "brightblack"  ))
-   (base6      '("#718CA1" "#6b6b6b" "brightblack"  ))
-   (base7      '("#7997AD" "#979797" "brightblack"  ))
-   (base8      '("#CBD1E1" "#dfdfdf" "white"        ))
-   (fg         '("#B7C5D3" "#bfbfbf" "brightwhite"  ))
-   (fg-alt     '("#CBD1E1" "#2d2d2d" "white"        ))
+  ((bg         '("#1D252C" nil       nil            ))
+   (bg-alt     '("#181E24" nil       nil            ))
+   (base0      '("#10151C" "black"   "black"        ))
+   (base1      '("#171D22" "#1e1e1e" "brightblack"  ))
+   (base2      '("#20282F" "#2e2e2e" "brightblack"  ))
+   (base3      '("#28323B" "#262626" "brightblack"  ))
+   (base4      '("#384551" "#3f3f3f" "brightblack"  ))
+   (base5      '("#56697A" "#525252" "brightblack"  ))
+   (base6      '("#688094" "#6b6b6b" "brightblack"  ))
+   (base7      '("#7FA0B7" "#979797" "brightblack"  ))
+   (base8      '("#9CAABB" "#dfdfdf" "white"        ))
+   (fg-alt     '("#728CA0" "#bfbfbf" "brightwhite"  ))
+   (fg         '("#A0B3C5" "#2d2d2d" "white"        ))
 
    (grey       base4)
    (red        '("#D95468" "#ff6655" "red"          ))
@@ -61,7 +61,7 @@ determine the exact padding."
 
    ;; face categories -- required for all themes
    (highlight      blue)
-   (vertical-bar   (doom-darken base1 0.2))
+   (vertical-bar   (doom-darken base1 0.5))
    (selection      dark-blue)
    (builtin        blue)
    (comments       (if doom-citylights-brighter-comments dark-cyan base5))
@@ -95,14 +95,14 @@ determine the exact padding."
 
    (modeline-bg
     (if -modeline-bright
-        (doom-darken blue 0.475)
-      `(,(doom-darken (car bg-alt) 0.15) ,@(cdr base0))))
+        (doom-darken blue 0.65)
+      `(,(doom-darken (car bg) 0.15) ,@(cdr base0))))
    (modeline-bg-l
     (if -modeline-bright
-        (doom-darken blue 0.45)
-      `(,(doom-darken (car bg-alt) 0.1) ,@(cdr base0))))
-   (modeline-bg-inactive   (doom-darken bg-alt 0.1))
-   (modeline-bg-inactive-l `(,(car bg-alt) ,@(cdr base1))))
+        (doom-darken blue 0.65)
+      `(,(doom-darken (car bg) 0.1) ,@(cdr base0))))
+   (modeline-bg-inactive   (doom-darken bg 0.1))
+   (modeline-bg-inactive-l `(,(car bg) ,@(cdr base1))))
 
 
   ;; --- extra faces ------------------------

--- a/themes/doom-dracula-theme.el
+++ b/themes/doom-dracula-theme.el
@@ -39,8 +39,8 @@ determine the exact padding."
   "A dark theme inspired by Atom One Dark"
 
   ;; name        default   256       16
-  ((bg         '("#1E2029" nil       nil            ))
-   (bg-alt     '("#282a36" nil       nil            ))
+  ((bg         '("#282a36" nil       nil            ))
+   (bg-alt     '("#1E2029" nil       nil            ))
    (base0      '("#1E2029" "black"   "black"        ))
    (base1      '("#282a36" "#1e1e1e" "brightblack"  ))
    (base2      '("#373844" "#2e2e2e" "brightblack"  ))
@@ -50,8 +50,8 @@ determine the exact padding."
    (base6      '("#b6b6b2" "#6b6b6b" "brightblack"  ))
    (base7      '("#ccccc7" "#979797" "brightblack"  ))
    (base8      '("#f8f8f2" "#dfdfdf" "white"        ))
-   (fg         '("#e2e2dc" "#bfbfbf" "brightwhite"  ))
-   (fg-alt     '("#f8f8f2" "#2d2d2d" "white"        ))
+   (fg         '("#f8f8f2" "#2d2d2d" "white"        ))
+   (fg-alt     '("#e2e2dc" "#bfbfbf" "brightwhite"  ))
 
    (grey       base4)
    (red        '("#ff5555" "#ff6655" "red"          ))
@@ -111,15 +111,16 @@ determine the exact padding."
    (modeline-fg-alt base5)
 
    (modeline-bg
+
     (if -modeline-bright
-        (doom-darken  0.475)
-      `(,(car bg-alt) ,@(cdr base0))))
+        (doom-darken  magenta 0.675)
+      `(,(car bg) ,@(cdr base0))))
    (modeline-bg-l
     (if -modeline-bright
-        (doom-darken magenta 0.45)
-      `(,(doom-darken (car bg-alt) 0.15) ,@(cdr base0))))
-   (modeline-bg-inactive   (doom-darken bg-alt 0.1))
-   (modeline-bg-inactive-l `(,(doom-darken (car bg-alt) 0.075) ,@(cdr base1))))
+        (doom-darken magenta 0.6)
+      `(,(doom-darken (car bg) 0.15) ,@(cdr base0))))
+   (modeline-bg-inactive   (doom-darken bg 0.1))
+   (modeline-bg-inactive-l `(,(doom-darken (car bg) 0.075) ,@(cdr base1))))
 
 
   ;; --- extra faces ------------------------

--- a/themes/doom-nord-theme.el
+++ b/themes/doom-nord-theme.el
@@ -58,7 +58,7 @@ determine the exact padding."
    (magenta    '("#B58DAE" "#c678dd" "magenta"      ))
    (violet     '("#5D80AE" "#a9a1e1" "brightmagenta"))
    (cyan       '("#86C0D1" "#46D9FF" "brightcyan"   ))
-   (dark-cyan  '("#507681" "#2257A0" "blue"         ))
+   (dark-cyan  '("#507681" "#5699AF" "cyan"         ))
 
    ;; face categories -- required for all themes
    (highlight      blue)

--- a/themes/doom-nord-theme.el
+++ b/themes/doom-nord-theme.el
@@ -33,19 +33,19 @@ determine the exact padding."
   "A dark theme inspired by Atom One Dark"
 
   ;; name        default   256       16
-  ((bg         '("#2E3440" nil       nil            ))
-   (bg-alt     '("#3B4253" nil       nil            ))
-   (base0      '("#2E3440" "black"   "black"        ))
-   (base1      '("#3B4253" "#1e1e1e" "brightblack"  ))
-   (base2      '("#434C5F" "#2e2e2e" "brightblack"  ))
-   (base3      '("#4C566B" "#262626" "brightblack"  ))
-   (base4      '("#545F76" "#3f3f3f" "brightblack"  ))
-   (base5      '("#67748F" "#525252" "brightblack"  ))
-   (base6      '("#D8DEE9" "#6b6b6b" "brightblack"  ))
-   (base7      '("#E5E9F0" "#979797" "brightblack"  ))
-   (base8      '("#ECEFF4" "#dfdfdf" "white"        ))
-   (fg         '("#E5E9F0" "#bfbfbf" "brightwhite"  ))
-   (fg-alt     '("#ECEFF4" "#2d2d2d" "white"        ))
+  ((bg         '("#3B4253" nil       nil            ))
+   (bg-alt     '("#2E3440" nil       nil            ))
+   (base0      '("#1A1D25" "black"   "black"        ))
+   (base1      '("#282C39" "#1e1e1e" "brightblack"  ))
+   (base2      '("#383F51" "#2e2e2e" "brightblack"  ))
+   (base3      '("#414A5D" "#262626" "brightblack"  ))
+   (base4      '("#495368" "#3f3f3f" "brightblack"  ))
+   (base5      '("#5C6881" "#525252" "brightblack"  ))
+   (base6      '("#6B7996" "#6b6b6b" "brightblack"  ))
+   (base7      '("#7D8DAE" "#979797" "brightblack"  ))
+   (base8      '("#91A4CB" "#dfdfdf" "white"        ))
+   (fg         '("#ECEFF4" "#2d2d2d" "white"        ))
+   (fg-alt     '("#E5E9F0" "#bfbfbf" "brightwhite"  ))
 
    (grey       base4)
    (red        '("#C16069" "#ff6655" "red"          ))
@@ -95,14 +95,14 @@ determine the exact padding."
 
    (modeline-bg
     (if -modeline-bright
-        (doom-darken blue 0.475)
-      `(,(doom-darken (car bg-alt) 0.15) ,@(cdr base0))))
+        (doom-darken blue 0.55)
+      `(,(doom-darken (car bg) 0.15) ,@(cdr base0))))
    (modeline-bg-l
     (if -modeline-bright
-        (doom-darken blue 0.45)
-      `(,(doom-darken (car bg-alt) 0.1) ,@(cdr base0))))
-   (modeline-bg-inactive   (doom-darken bg-alt 0.1))
-   (modeline-bg-inactive-l `(,(car bg-alt) ,@(cdr base1))))
+        (doom-darken blue 0.55)
+      `(,(doom-darken (car bg) 0.1) ,@(cdr base0))))
+   (modeline-bg-inactive   (doom-darken bg 0.1))
+   (modeline-bg-inactive-l `(,(car bg) ,@(cdr base1))))
 
 
   ;; --- extra faces ------------------------

--- a/themes/doom-nord-theme.el
+++ b/themes/doom-nord-theme.el
@@ -58,6 +58,7 @@ determine the exact padding."
    (magenta    '("#B58DAE" "#c678dd" "magenta"      ))
    (violet     '("#5D80AE" "#a9a1e1" "brightmagenta"))
    (cyan       '("#86C0D1" "#46D9FF" "brightcyan"   ))
+   (dark-cyan  '("#507681" "#2257A0" "blue"         ))
 
    ;; face categories -- required for all themes
    (highlight      blue)

--- a/themes/doom-solarized-light-theme.el
+++ b/themes/doom-solarized-light-theme.el
@@ -33,8 +33,8 @@ determine the exact padding."
   "A light theme inspired by Solarized light"
 
   ;; name        default   256       16
-  ((bg         '("#FCF8ED" nil       nil            ))
-   (bg-alt     '("#FDF6E3" nil       nil            ))
+  ((bg         '("#FDF6E3" nil       nil            ))
+   (bg-alt     '("#FFFBEA" nil       nil            ))
    (base0      '("#FFFBF0" "black"   "black"        ))
    (base1      '("#FCF8ED" "#1e1e1e" "brightblack"  ))
    (base2      '("#FCF7E8" "#2e2e2e" "brightblack"  ))
@@ -44,8 +44,8 @@ determine the exact padding."
    (base6      '("#B0AFAF" "#6b6b6b" "brightblack"  ))
    (base7      '("#788484" "#979797" "brightblack"  ))
    (base8      '("#626C6C" "#dfdfdf" "white"        ))
-   (fg         '("#7B8787" "#bfbfbf" "brightwhite"  ))
-   (fg-alt     '("#6B7A7C" "#2d2d2d" "white"        ))
+   (fg         '("#6B7A7C" "#2d2d2d" "white"        ))
+   (fg-alt     '("#7B8787" "#bfbfbf" "brightwhite"  ))
 
    (grey       base4)
    (red        '("#dc322f" "#ff6655" "red"          ))
@@ -96,14 +96,14 @@ determine the exact padding."
 
    (modeline-bg
     (if -modeline-bright
-        (doom-darken blue 0.475)
-      `(,(doom-darken (car bg-alt) 0.02) ,@(cdr base0))))
+        (doom-lighten bg 0.7)
+      `(,(doom-lighten (car bg) 0.25) ,@(cdr base0))))
    (modeline-bg-l
     (if -modeline-bright
-        (doom-darken blue 0.45)
-      `(,(doom-darken (car bg-alt) 0.025) ,@(cdr base0))))
-   (modeline-bg-inactive   (doom-darken bg-alt 0.02))
-   (modeline-bg-inactive-l `(,(car bg-alt) ,@(cdr base1))))
+        (doom-lighten bg 0.7)
+      `(,(doom-lighten (car bg) 0.25) ,@(cdr base0))))
+   (modeline-bg-inactive   (doom-lighten bg 0.02))
+   (modeline-bg-inactive-l `(,(car bg) ,@(cdr base1))))
 
 
   ;; --- extra faces ------------------------
@@ -158,6 +158,8 @@ determine the exact padding."
    (markdown-header-face :inherit 'bold :foreground red)
    (markdown-code-face :background (doom-lighten base3 0.05))
 
+   ;; posframe
+   (ivy-posframe :background (doom-lighten bg 0.3))
    ;; org-mode
    (org-hide :foreground hidden)
    (solaire-org-hide-face :foreground hidden))


### PR DESCRIPTION
This PR fixes the fg/bg without solaire-mode and modeline color when modeline-brighter is t in the following themes:
- Solarized light
- Citylights
- Nord
- Dracula
