### PR TITLE
Darker comments possibility for Solarized Light

### DIFF
--- a/themes/doom-solarized-light-theme.el
+++ b/themes/doom-solarized-light-theme.el
@@ -28,10 +28,11 @@ be displayed in slightly darker colors."
   :group 'doom-solarized-light-theme
   :type 'boolean)
 
-(defcustom doom-solarized-light-darker-doc-comments nil
-  "If non-nil, doc-comments will be displayed in slightly darker colors."
+(defcustom doom-solarized-light-padded-modeline nil
+  "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
+determine the exact padding."
   :group 'doom-solarized-light-theme
-  :type 'boolean)
+  :type '(or integer boolean))
 
 ;;
 (def-doom-theme doom-solarized-light

--- a/themes/doom-solarized-light-theme.el
+++ b/themes/doom-solarized-light-theme.el
@@ -22,8 +22,9 @@ legibility."
   :group 'doom-solarized-light-theme
   :type 'boolean)
 
-(defcustom doom-solarized-light-darker-doc-comments nil
-  "If non-nil, doc-comments will be displayed in slightly darker colors."
+(defcustom doom-solarized-light-darker-comments nil
+  "If non-nil, and doom-solarized-light-brighter-comments is nil, comments will
+be displayed in slightly darker colors."
   :group 'doom-solarized-light-theme
   :type 'boolean)
 
@@ -69,10 +70,11 @@ legibility."
    (vertical-bar   base3)
    (selection      dark-blue)
    (builtin        magenta)
-   (comments       (if doom-solarized-light-brighter-comments dark-cyan base5))
-   (doc-comments   (if doom-solarized-light-darker-doc-comments
-                       (doom-blend base6 fg 0.8)
-                     (doom-blend dark-cyan fg 0.8)))
+   (comments       (cond
+                    (doom-solarized-light-brighter-comments dark-cyan)
+                    (doom-solarized-light-darker-comments base6)
+                    (t base5)))
+   (doc-comments   (doom-blend dark-cyan fg 0.8))
    (constants      violet)
    (functions      magenta)
    (keywords       blue)

--- a/themes/doom-solarized-light-theme.el
+++ b/themes/doom-solarized-light-theme.el
@@ -22,17 +22,15 @@ legibility."
   :group 'doom-solarized-light-theme
   :type 'boolean)
 
-(defcustom doom-solarized-light-darker-comments nil
-  "If non-nil, and doom-solarized-light-brighter-comments is nil, comments will
-be displayed in slightly darker colors."
+(defcustom doom-solarized-light-darker-doc-comments nil
+  "If non-nil, doc-comments will be displayed in slightly darker colors."
   :group 'doom-solarized-light-theme
   :type 'boolean)
 
-(defcustom doom-solarized-light-padded-modeline nil
-  "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
-determine the exact padding."
+(defcustom doom-solarized-light-darker-doc-comments nil
+  "If non-nil, doc-comments will be displayed in slightly darker colors."
   :group 'doom-solarized-light-theme
-  :type '(or integer boolean))
+  :type 'boolean)
 
 ;;
 (def-doom-theme doom-solarized-light
@@ -71,11 +69,8 @@ determine the exact padding."
    (vertical-bar   base3)
    (selection      dark-blue)
    (builtin        magenta)
-   (comments       (cond
-                    (doom-solarized-light-brighter-comments dark-cyan)
-                    (doom-solarized-light-darker-comments base6)
-                    (t base5)))
-   (doc-comments   (if doom-solarized-light-darker-comments
+   (comments       (if doom-solarized-light-brighter-comments dark-cyan base5))
+   (doc-comments   (if doom-solarized-light-darker-doc-comments
                        (doom-blend base6 fg 0.8)
                      (doom-blend dark-cyan fg 0.8)))
    (constants      violet)

--- a/themes/doom-solarized-light-theme.el
+++ b/themes/doom-solarized-light-theme.el
@@ -22,6 +22,12 @@ legibility."
   :group 'doom-solarized-light-theme
   :type 'boolean)
 
+(defcustom doom-solarized-light-darker-comments nil
+  "If non-nil, and doom-solarized-light-brighter-comments is nil, comments will
+be displayed in slightly darker colors."
+  :group 'doom-solarized-light-theme
+  :type 'boolean)
+
 (defcustom doom-solarized-light-padded-modeline nil
   "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
 determine the exact padding."
@@ -65,8 +71,13 @@ determine the exact padding."
    (vertical-bar   base3)
    (selection      dark-blue)
    (builtin        magenta)
-   (comments       (if doom-solarized-light-brighter-comments dark-cyan base5))
-   (doc-comments   (doom-blend dark-cyan fg 0.8))
+   (comments       (cond
+                    (doom-solarized-light-brighter-comments dark-cyan)
+                    (doom-solarized-light-darker-comments base6)
+                    (t base5)))
+   (doc-comments   (if doom-solarized-light-darker-comments
+                       (doom-blend base6 fg 0.8)
+                     (doom-blend dark-cyan fg 0.8)))
    (constants      violet)
    (functions      magenta)
    (keywords       blue)


### PR DESCRIPTION
In the Solarized Light theme, base5 is used for comments, and it is defined extremely light to my eyes (Also atypically light compared to standard Solarized Light, I think). I would like to have the option to have the comments use base6 instead. I would also want to use base6 for doc-comments and modeline-fg-alt, but the most crucial is comments, so that's what I'm addressing here.

This uses a bit cruddy short circuit with doom-solarized-light-brighter-comments, but I didn't want to merge the defcustoms or do anything more complicated before I knew if this was any way desirable for anyone else.

This is what comments look like with the original base5:
![normal](https://user-images.githubusercontent.com/18103388/37879590-07a38d60-3084-11e8-857d-0fa26dc9a837.png)

This is what they would look like with base6:
![darker](https://user-images.githubusercontent.com/18103388/37879593-0f5a4864-3084-11e8-9dce-f357aaa55698.png)
