### PR TITLE
Add doom-themes-padded-modeline custom var

### DIFF
--- a/doom-themes.el
+++ b/doom-themes.el
@@ -83,6 +83,11 @@
   :group 'doom-themes
   :type 'boolean)
 
+(defcustom doom-themes-padded-modeline nil
+  "Default value for padded-modeline setting for themes that support it."
+  :group 'doom-themes
+  :type '(or integer boolean))
+
 (define-obsolete-variable-alias 'doom-enable-italic 'doom-themes-enable-italic "1.2.9")
 (define-obsolete-variable-alias 'doom-enable-bold   'doom-themes-enable-bold "1.2.9")
 

--- a/themes/doom-challenger-deep-theme.el
+++ b/themes/doom-challenger-deep-theme.el
@@ -22,7 +22,7 @@ legibility."
   :group 'doom-challenger-deep-theme
   :type 'boolean)
 
-(defcustom doom-challenger-deep-padded-modeline nil
+(defcustom doom-challenger-deep-padded-modeline doom-themes-padded-modeline
   "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
 determine the exact padding."
   :group 'doom-challenger-deep-theme

--- a/themes/doom-city-lights-theme.el
+++ b/themes/doom-city-lights-theme.el
@@ -22,7 +22,7 @@ legibility."
   :group 'doom-city-lights-theme
   :type 'boolean)
 
-(defcustom doom-city-lights-padded-modeline nil
+(defcustom doom-city-lights-padded-modeline doom-themes-padded-modeline
   "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
 determine the exact padding."
   :group 'doom-city-lights-theme

--- a/themes/doom-dracula-theme.el
+++ b/themes/doom-dracula-theme.el
@@ -28,7 +28,7 @@ legibility."
   :group 'doom-dracula-theme
   :type 'boolean)
 
-(defcustom doom-dracula-padded-modeline nil
+(defcustom doom-dracula-padded-modeline doom-themes-padded-modeline
   "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
 determine the exact padding."
   :group 'doom-dracula-theme

--- a/themes/doom-molokai-theme.el
+++ b/themes/doom-molokai-theme.el
@@ -11,7 +11,7 @@
   :group 'doom-molokai-theme
   :type 'boolean)
 
-(defcustom doom-molokai-padded-modeline nil
+(defcustom doom-molokai-padded-modeline doom-themes-padded-modeline
   "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
 determine the exact padding."
   :group 'doom-molokai-theme

--- a/themes/doom-nord-light-theme.el
+++ b/themes/doom-nord-light-theme.el
@@ -22,7 +22,7 @@ legibility."
   :group 'doom-nord-light-theme
   :type 'boolean)
 
-(defcustom doom-nord-light-padded-modeline nil
+(defcustom doom-nord-light-padded-modeline doom-themes-padded-modeline
   "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
 determine the exact padding."
   :group 'doom-nord-light-theme

--- a/themes/doom-nord-theme.el
+++ b/themes/doom-nord-theme.el
@@ -22,7 +22,7 @@ legibility."
   :group 'doom-nord-theme
   :type 'boolean)
 
-(defcustom doom-nord-padded-modeline nil
+(defcustom doom-nord-padded-modeline doom-themes-padded-modeline
   "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
 determine the exact padding."
   :group 'doom-nord-theme

--- a/themes/doom-nova-theme.el
+++ b/themes/doom-nova-theme.el
@@ -5,7 +5,7 @@
   "Options for doom-themes"
   :group 'doom-themes)
 
-(defcustom doom-nova-padded-modeline nil
+(defcustom doom-nova-padded-modeline doom-themes-padded-modeline
   "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
 determine the exact padding."
   :group 'doom-nova-theme

--- a/themes/doom-one-light-theme.el
+++ b/themes/doom-one-light-theme.el
@@ -22,7 +22,7 @@ legibility."
   :group 'doom-one-light-theme
   :type 'boolean)
 
-(defcustom doom-one-light-padded-modeline nil
+(defcustom doom-one-light-padded-modeline doom-themes-padded-modeline
   "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
 determine the exact padding."
   :group 'doom-one-light-theme

--- a/themes/doom-one-theme.el
+++ b/themes/doom-one-theme.el
@@ -22,7 +22,7 @@ legibility."
   :group 'doom-one-theme
   :type 'boolean)
 
-(defcustom doom-one-padded-modeline nil
+(defcustom doom-one-padded-modeline doom-themes-padded-modeline
   "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
 determine the exact padding."
   :group 'doom-one-theme

--- a/themes/doom-peacock-theme.el
+++ b/themes/doom-peacock-theme.el
@@ -21,7 +21,7 @@ legibility."
   :group 'doom-peacock-theme
   :type 'boolean)
 
-(defcustom doom-peacock-padded-modeline nil
+(defcustom doom-peacock-padded-modeline doom-themes-padded-modeline
   "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
 determine the exact padding."
   :group 'doom-peacock-theme

--- a/themes/doom-solarized-light-theme.el
+++ b/themes/doom-solarized-light-theme.el
@@ -22,7 +22,7 @@ legibility."
   :group 'doom-solarized-light-theme
   :type 'boolean)
 
-(defcustom doom-solarized-light-padded-modeline nil
+(defcustom doom-solarized-light-padded-modeline doom-themes-padded-modeline
   "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
 determine the exact padding."
   :group 'doom-solarized-light-theme

--- a/themes/doom-spacegrey-theme.el
+++ b/themes/doom-spacegrey-theme.el
@@ -21,7 +21,7 @@ legibility."
   :group 'doom-spacegrey-theme
   :type 'boolean)
 
-(defcustom doom-spacegrey-padded-modeline nil
+(defcustom doom-spacegrey-padded-modeline doom-themes-padded-modeline
   "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
 determine the exact padding."
   :group 'doom-spacegrey-theme

--- a/themes/doom-tomorrow-day-theme.el
+++ b/themes/doom-tomorrow-day-theme.el
@@ -10,7 +10,7 @@
   "Options for doom-themes"
   :group 'doom-themes)
 
-(defcustom doom-tomorrow-day-padded-modeline nil
+(defcustom doom-tomorrow-day-padded-modeline doom-themes-padded-modeline
   "If non-nil, adds a 4px padding to the mode-line.
 Can be an integer to determine the exact padding."
   :group 'doom-tomorrow-day-theme

--- a/themes/doom-tomorrow-night-theme.el
+++ b/themes/doom-tomorrow-night-theme.el
@@ -5,7 +5,7 @@
   "Options for doom-themes"
   :group 'doom-themes)
 
-(defcustom doom-tomorrow-night-padded-modeline nil
+(defcustom doom-tomorrow-night-padded-modeline doom-themes-padded-modeline
   "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
 determine the exact padding."
   :group 'doom-tomorrow-night-theme

--- a/themes/doom-vibrant-theme.el
+++ b/themes/doom-vibrant-theme.el
@@ -22,7 +22,7 @@ legibility."
   :group 'doom-vibrant-theme
   :type 'boolean)
 
-(defcustom doom-vibrant-padded-modeline nil
+(defcustom doom-vibrant-padded-modeline doom-themes-padded-modeline
   "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
 determine the exact padding."
   :group 'doom-vibrant-theme


### PR DESCRIPTION
Serves as the default value for the padded-modeline variable for themes that
have one