### PR TITLE
Add: org-indent face

### DIFF
--- a/doom-themes-common.el
+++ b/doom-themes-common.el
@@ -1085,6 +1085,7 @@
     (org-formula                  :foreground cyan)
     (org-headline-done            :foreground base5)
     (org-hide                     :foreground bg)
+    (org-indent                   :foreground bg)
 
     (org-level-1 :foreground blue     :background base3 :weight 'ultra-bold :height 1.25)
     (org-level-2 :foreground magenta  :weight 'semi-bold)


### PR DESCRIPTION
This fontifies org-indent to match the `org-default` face so that indentation characters match the color of the background.  This is important in case the org-indent character is not a space (e.g. when using variable-pitch fonts in Org buffers, using a * for indentation is better than a space, because it aligns entry content with headlines, while spaces result in content that is not indented enough).