### PR TITLE
Add background for ivy-current-match

### DIFF
--- a/themes/doom-nord-theme.el
+++ b/themes/doom-nord-theme.el
@@ -178,7 +178,10 @@ determine the exact padding."
 
    ;; org-mode
    (org-hide :foreground hidden)
-   (solaire-org-hide-face :foreground hidden))
+   (solaire-org-hide-face :foreground hidden)
+   
+  ;; ivy
+   (ivy-current-match :background "#626774"))
 
 
   ;; --- extra variables ---------------------


### PR DESCRIPTION
Can't see what line is currently selected when using swiper as is