### PR TITLE
Change git-commit-note to git-commit-keyword

### DIFF
--- a/doom-themes-common.el
+++ b/doom-themes-common.el
@@ -499,7 +499,7 @@
     (git-commit-summary :foreground strings)
     (git-commit-overlong-summary :inherit 'error :background base0 :slant 'italic :weight 'bold)
     (git-commit-nonempty-second-line :inherit 'git-commit-overlong-summary)
-    (git-commit-note :foreground cyan :slant 'italic)
+    (git-commit-keyword :foreground cyan :slant 'italic)
     (git-commit-pseudo-header :foreground doc-comments :slant 'italic)
     (git-commit-known-pseudo-header :foreground doc-comments :weight 'bold :slant 'italic)
     (git-commit-comment-branch-local :foreground magenta)


### PR DESCRIPTION
This was changed in this commit: https://github.com/magit/magit/commit/3718544b55b10b4e78a31ba4044fbaa9f2e9e2e1