### PR TITLE
Add TeX-error-description-* faces

### DIFF
--- a/doom-themes-common.el
+++ b/doom-themes-common.el
@@ -1035,6 +1035,10 @@
     (font-latex-warning-face      :inherit 'font-lock-warning-face)
     (font-latex-verbatim-face     :inherit 'fixed-pitch :foreground violet :slant 'italic)
 
+    (TeX-error-description-error    :inherit 'error   :weight 'bold)
+    (TeX-error-description-warning  :inherit 'warning :weight 'bold)
+    (TeX-error-description-tex-said :inherit 'success :weight 'bold)
+
     ;; elixir-mode
     (elixir-atom-face (&light :foreground dark-blue)
                       (&dark  :foreground cyan))


### PR DESCRIPTION
These faces are used when invoking `` C-c ` `` to display the list of errors from a TeX-mode buffer.  I modeled them after the compilation-mode faces, but do not want to inherit since `compile.el` will not necessarily be loaded.