### PR TITLE
one-light: don't set solaire-hl-line-face

### DIFF
--- a/themes/doom-one-light-theme.el
+++ b/themes/doom-one-light-theme.el
@@ -116,8 +116,6 @@ determine the exact padding."
    ((line-number &override) :foreground (doom-lighten base4 0.15))
    ((line-number-current-line &override) :foreground base8)
 
-   (solaire-hl-line-face :inherit 'hl-line :background base0)
-
    (doom-modeline-bar :background (if -modeline-bright modeline-bg highlight))
 
    (mode-line


### PR DESCRIPTION
instead fallback to the one set from doom-themes-common

otherwise in buffers like treemacs it results in the same background color as hl-line face