### PR TITLE
Set treemacs closed folder icon to not slanted

### DIFF
--- a/doom-themes-treemacs.el
+++ b/doom-themes-treemacs.el
@@ -91,7 +91,7 @@ pane and are highlighted incorrectly when used with `solaire-mode'."
               (concat (all-the-icons-octicon "file-directory" :v-adjust 0)
                       " ")
               treemacs-icon-closed-png
-              (concat (all-the-icons-octicon "file-directory" :v-adjust 0 :face 'font-lock-doc-face)
+              (concat (all-the-icons-octicon "file-directory" :v-adjust 0 :face '(:inherit font-lock-doc-face :slant normal))
                       " ")
 
               treemacs-icon-tag-node-open-png


### PR DESCRIPTION
`treemacs-icon-closed-png` inherits attributes from `font-lock-doc-face`, which may be italicized in some themes, e.g. `doom-one-light`. This causes the closed folder icon to appear slanted in those themes.

This commit explicitly sets the face to `:slant normal`, so that closed folders are never italicized/slanted.

For example, doom-one-light treemacs _before_:

<img width="1014" alt="before" src="https://user-images.githubusercontent.com/286057/54579887-f0e95600-49db-11e9-9ea2-1cb2c2a7918d.png">

And _after_ (note the folders are no longer slanted):

<img width="967" alt="after" src="https://user-images.githubusercontent.com/286057/54579928-18402300-49dc-11e9-8d2c-0e40d58f9687.png">

