### PR TITLE
Register treemacs-tags-face to also get variable-pitched

### DIFF
--- a/doom-themes-treemacs.el
+++ b/doom-themes-treemacs.el
@@ -45,7 +45,8 @@ pane and are highlighted incorrectly when used with `solaire-mode'."
                     treemacs-git-conflict-face
                     treemacs-directory-face
                     treemacs-directory-collapsed-face
-                    treemacs-file-face))
+                    treemacs-file-face
+                    treemacs-tags-face))
       (let ((faces (face-attribute face :inherit nil)))
         (set-face-attribute
          face nil :inherit


### PR DESCRIPTION
Not sure if this was intentional, but tags in non-variable pitch face look out of place when everything else is variable-pitched.