### PR TITLE
Set face for hl-fill-column

### DIFF
--- a/doom-themes-base.el
+++ b/doom-themes-base.el
@@ -190,6 +190,9 @@
     ;; (hi-black-b  :weight 'bold)
     ;; (hi-black-hb :inherit 'variable-pitch :weight 'bold :height 1.67)
 
+    ;; hl-fill-column-face
+    (hl-fill-column-face :inherit 'shadow)
+
     ;; hl-line
     (hl-line :background bg-alt)
 


### PR DESCRIPTION
When using `hl-fill-column` it get rid off the message `Unable to load color "brightblack"`.