### PR TITLE
Themed centaur-tabs

### DIFF
--- a/doom-themes-common.el
+++ b/doom-themes-common.el
@@ -342,6 +342,16 @@
     (cfw:face-disable            :foreground grey)
     (cfw:face-select             :background region)
 
+    ;; centaur-tabs
+    (centaur-tabs-default    :background bg-alt :foreground bg-alt)
+    (centaur-tabs-selected   :background bg :foreground fg)
+    (centaur-tabs-unselected :background bg-alt :foreground fg-alt)
+    (centaur-tabs-selected-modified   :background bg :foreground teal)
+    (centaur-tabs-unselected-modified :background bg-alt :foreground teal)
+    (centaur-tabs-active-bar-face :background (if -modeline-bright modeline-bg highlight))
+    (centaur-tabs-modified-marker-selected :inherit 'centaur-tabs-selected :foreground (if -modeline-bright modeline-bg highlight))
+    (centaur-tabs-modified-marker-unselected :inherit 'centaur-tabs-unselected :foreground (if -modeline-bright modeline-bg highlight))
+    
     ;; company
     (company-tooltip            :inherit 'tooltip)
     (company-tooltip-common                           :foreground highlight :distant-foreground base0 :weight 'bold)

--- a/themes/doom-molokai-theme.el
+++ b/themes/doom-molokai-theme.el
@@ -113,6 +113,9 @@ determine the exact padding."
     :background modeline-bg-inactive :foreground modeline-fg-alt
     :box (if -modeline-pad `(:line-width ,-modeline-pad :color modeline-bg-inactive)))
 
+   ;; Centaur tabs
+   (centaur-tabs-active-bar-face :background green)
+
    ;; Doom modeline
    (doom-modeline-bar :background green)
    (doom-modeline-buffer-file :inherit 'mode-line-buffer-id :weight 'bold)


### PR DESCRIPTION
This fixes #291. It looks like this:

![DeepinScreenshot_select-area_20190628223255](https://user-images.githubusercontent.com/17773218/60379714-ee43c700-99f4-11e9-96d0-47d8e04c8d4a.png)

Notice the selected tab bar matches the doom modeline bar which looks really nice