### PR TITLE
Tomorrow-Night: change fg-alt darken to increase visibility

### DIFF
--- a/themes/doom-tomorrow-night-theme.el
+++ b/themes/doom-tomorrow-night-theme.el
@@ -27,7 +27,7 @@ determine the exact padding."
    (base7      '("#969896" "#979797" "brightblack"))
    (base8      '("#ffffff" "#ffffff" "white"      ))
    (fg         '("#c5c8c6" "#c5c5c5" "white"))
-   (fg-alt     (doom-darken fg 0.6))
+   (fg-alt     (doom-darken fg 0.4))
 
    (grey       '("#5a5b5a" "#5a5a5a" "brightblack"))
    (red        '("#cc6666" "#cc6666" "red"))


### PR DESCRIPTION
I have solved my problem in issue #301 by changing the value of fg-alt from being darkened by 0.6 to 0.4.

Here's a quick before-and-after: **Notice the tabs font colors**

## Before

<img width="1920" alt="61108054-f0595b80-a4b3-11e9-8d97-7e990994fc60" src="https://user-images.githubusercontent.com/36686900/61181715-757f7480-a65c-11e9-8754-aa17c5105de7.png">


## After

<img width="1920" alt="Screenshot 2019-07-14 at 5 25 03 PM" src="https://user-images.githubusercontent.com/36686900/61181718-7fa17300-a65c-11e9-9b9b-abf6d0c11e91.png">
