### PR TITLE
Fix a bug with mismatching (provide) and filename

### DIFF
--- a/doom-themes-ext-org.el
+++ b/doom-themes-ext-org.el
@@ -86,5 +86,5 @@ See also `org-agenda-deadline-faces'."
 (defun doom-themes-org-config ()
   "Enable custom fontification & improves theme integration with org-mode.")
 
-(provide 'doom-themes-org)
-;;; doom-themes-org.el ends here
+(provide 'doom-themes-ext-org)
+;;; doom-themes-ext-org.el ends here


### PR DESCRIPTION
If not using MELPA for doom-themes, require didn't work properly with the org-mode extension because of mismatching filename and `(provide)`.