### PR TITLE
Add color helper functions

### DIFF
--- a/doom-themes.el
+++ b/doom-themes.el
@@ -391,6 +391,118 @@ theme face specs. These is a simplified spec. For example:
     (add-to-list 'custom-theme-load-path
                  (or (and (file-directory-p dir) dir)
                      base))))
+;;; Auto color
+
+(defun doom-gencolor (color)
+  "Return three colors derived from COLOR: (COLOR 8-bit 4-bit)."
+  (list color (doom-closest-8-bit-color color) (doom-closest-4-bit-color color)))
+
+(defvar doom--8-bit-color-list
+  '("#000000" "#800000" "#008000" "#808000" "#000080" "#800080"
+    "#008080" "#c0c0c0" "#808080" "#ff0000" "#00ff00" "#ffff00"
+    "#0000ff" "#ff00ff" "#00ffff" "#ffffff" "#000000" "#00005f"
+    "#000087" "#0000af" "#0000d7" "#0000ff" "#005f00" "#005f5f"
+    "#005f87" "#005faf" "#005fd7" "#005fff" "#008700" "#00875f"
+    "#008787" "#0087af" "#0087d7" "#0087ff" "#00af00" "#00af5f"
+    "#00af87" "#00afaf" "#00afd7" "#00afff" "#00d700" "#00d75f"
+    "#00d787" "#00d7af" "#00d7d7" "#00d7ff" "#00ff00" "#00ff5f"
+    "#00ff87" "#00ffaf" "#00ffd7" "#00ffff" "#5f0000" "#5f005f"
+    "#5f0087" "#5f00af" "#5f00d7" "#5f00ff" "#5f5f00" "#5f5f5f"
+    "#5f5f87" "#5f5faf" "#5f5fd7" "#5f5fff" "#5f8700" "#5f875f"
+    "#5f8787" "#5f87af" "#5f87d7" "#5f87ff" "#5faf00" "#5faf5f"
+    "#5faf87" "#5fafaf" "#5fafd7" "#5fafff" "#5fd700" "#5fd75f"
+    "#5fd787" "#5fd7af" "#5fd7d7" "#5fd7ff" "#5fff00" "#5fff5f"
+    "#5fff87" "#5fffaf" "#5fffd7" "#5fffff" "#870000" "#87005f"
+    "#870087" "#8700af" "#8700d7" "#8700ff" "#875f00" "#875f5f"
+    "#875f87" "#875faf" "#875fd7" "#875fff" "#878700" "#87875f"
+    "#878787" "#8787af" "#8787d7" "#8787ff" "#87af00" "#87af5f"
+    "#87af87" "#87afaf" "#87afd7" "#87afff" "#87d700" "#87d75f"
+    "#87d787" "#87d7af" "#87d7d7" "#87d7ff" "#87ff00" "#87ff5f"
+    "#87ff87" "#87ffaf" "#87ffd7" "#87ffff" "#af0000" "#af005f"
+    "#af0087" "#af00af" "#af00d7" "#af00ff" "#af5f00" "#af5f5f"
+    "#af5f87" "#af5faf" "#af5fd7" "#af5fff" "#af8700" "#af875f"
+    "#af8787" "#af87af" "#af87d7" "#af87ff" "#afaf00" "#afaf5f"
+    "#afaf87" "#afafaf" "#afafd7" "#afafff" "#afd700" "#afd75f"
+    "#afd787" "#afd7af" "#afd7d7" "#afd7ff" "#afff00" "#afff5f"
+    "#afff87" "#afffaf" "#afffd7" "#afffff" "#d70000" "#d7005f"
+    "#d70087" "#d700af" "#d700d7" "#d700ff" "#d75f00" "#d75f5f"
+    "#d75f87" "#d75faf" "#d75fd7" "#d75fff" "#d78700" "#d7875f"
+    "#d78787" "#d787af" "#d787d7" "#d787ff" "#d7af00" "#d7af5f"
+    "#d7af87" "#d7afaf" "#d7afd7" "#d7afff" "#d7d700" "#d7d75f"
+    "#d7d787" "#d7d7af" "#d7d7d7" "#d7d7ff" "#d7ff00" "#d7ff5f"
+    "#d7ff87" "#d7ffaf" "#d7ffd7" "#d7ffff" "#ff0000" "#ff005f"
+    "#ff0087" "#ff00af" "#ff00d7" "#ff00ff" "#ff5f00" "#ff5f5f"
+    "#ff5f87" "#ff5faf" "#ff5fd7" "#ff5fff" "#ff8700" "#ff875f"
+    "#ff8787" "#ff87af" "#ff87d7" "#ff87ff" "#ffaf00" "#ffaf5f"
+    "#ffaf87" "#ffafaf" "#ffafd7" "#ffafff" "#ffd700" "#ffd75f"
+    "#ffd787" "#ffd7af" "#ffd7d7" "#ffd7ff" "#ffff00" "#ffff5f"
+    "#ffff87" "#ffffaf" "#ffffd7" "#ffffff" "#080808" "#121212"
+    "#1c1c1c" "#262626" "#303030" "#3a3a3a" "#444444" "#4e4e4e"
+    "#585858" "#606060" "#666666" "#767676" "#808080" "#8a8a8a"
+    "#949494" "#9e9e9e" "#a8a8a8" "#b2b2b2" "#bcbcbc" "#c6c6c6"
+    "#d0d0d0" "#dadada" "#e4e4e4" "#eeeeee")
+  "8-bit colors.")
+
+(defvar doom--4-bit-color-list
+  '("#000000" "#0000FF" "#00FF00" "#00FFFF" "#000080" "#008000"
+    "#008080" "#800000" "#800080" "#808000" "#808080" "#C0C0C0"
+    "#FF0000" "#FF00FF" "#FFFF00" "#FFFFFF")
+  "4-bit colors.")
+
+(defvar doom-color-distance-fn
+  (lambda (c1 c2)
+    (let ((r1 (nth 0 c1))
+          (g1 (nth 1 c1))
+          (b1 (nth 2 c1))
+          (r2 (nth 0 c2))
+          (g2 (nth 1 c2))
+          (b2 (nth 2 c2)))
+      (+ (expt (- r1 r2) 2)
+         (expt (- g1 g2) 2)
+         (expt (- b1 b2) 2))))
+  "Function (color1 color2) -> number that returns the distance between color1 and color2.
+There is no specification on the range of the returned number as long as greater number
+implies greater distance.
+Each color is like (R G B) where R, G, B are number.
+
+More on https://en.wikipedia.org/wiki/Color_difference")
+
+(defun doom-color-distance (color1 color2)
+  "Return the distance between COLOR1 and COLOR2.
+COLOR’s are in the form of ”#RRGGBB”."
+  (funcall doom-color-distance-fn
+           (doom-color-str-to-list color1)
+           (doom-color-str-to-list color2)))
+
+(defun doom-color-str-to-list (color)
+  "Convert COLOR ”#RRGGBB” to (R G B)."
+  (list (string-to-number (substring color 1 3) 16)
+        (string-to-number (substring color 3 5) 16)
+        (string-to-number (substring color 5 7) 16)))
+
+(defun doom-color-list-to-str (color)
+  "Convert COLOR (R G B) to ”#RRGGBB”."
+  (format "#%.2x%.2x%.2x" (nth 0 color) (nth 1 color) (nth 2 color)))
+
+(defun doom--closest-color-in-list (color color-list)
+  "Return the color closest to COLOR from COLOR-LIST."
+  (let (closest-color
+        (min-distance 1.0e+INF))
+    (dolist (a-color color-list)
+      (let ((new-dist (doom-color-distance color a-color)))
+        (when (< new-dist min-distance)
+          (setq min-distance new-dist
+                closest-color a-color))))
+    closest-color))
+
+(defun doom-closest-8-bit-color (color)
+  "Return the closest 8 bit color to COLOR."
+  (doom--closest-color-in-list color doom--8-bit-color-list))
+
+(defun doom-closest-4-bit-color (color)
+  "Return the closest 4 bit color to COLOR."
+  (doom--closest-color-in-list color doom--4-bit-color-list))
+
 
 (provide 'doom-themes)
 ;;; doom-themes.el ends here


### PR DESCRIPTION
I wrote a helper function `doom-gencolor` that generates 8-bit and 4-bit colors automatically from a true color.

It works like this:
```elisp
(doom-gencolor "#ffaa33")
("#ffaa33" "#ffaf5f" "#FFFF00")
```

So I can write:
```elisp
   (red        (doom-gencolor "#e45649"))
   (orange     (doom-gencolor "#da8548"))
   (green      (doom-gencolor "#50a14f"))
   (teal       (doom-gencolor "#4db5bd"))
   (yellow     (doom-gencolor "#986801"))
   (blue       (doom-gencolor "#4078f2"))
   (blue-alt   (doom-gencolor "#a0bcf8"))
   (magenta    (doom-gencolor "#a626a4"))
   (violet     (doom-gencolor "#b751b6"))
   (cyan       (doom-gencolor "#0184bc"))
```

Instead of typing colors by hand.