### PR TITLE
Treemacs colorful icon theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ DOOM Themes is an opinionated UI plugin and pack of themes extracted from my
 
     This requires `all-the-icons`' fonts to be installed: `M-x
     all-the-icons-install-fonts`
-  - `(doom-themes-treemacs-config)`: a [treemacs] icon theme that takes after
-    [Atom]'s (WIP).
+  - `(doom-themes-treemacs-config)`: two [treemacs] icon themes, one that takes after
+    [Atom]'s, and a second more colorful implementation (WIP).
   - `(doom-themes-org-config)`: corrects and improves some of org-mode's native
     fontification.
     -  Re-set `org-todo' & `org-headline-done' faces to make them respect
@@ -101,6 +101,7 @@ A comprehensive configuration example:
 ;; Enable custom neotree theme (all-the-icons must be installed!)
 (doom-themes-neotree-config)
 ;; or for treemacs users
+(doom-themes-treemacs-color-icons t) ;; set to t for a more colorful less minimalistic Treemacs theme
 (doom-themes-treemacs-config)
 
 ;; Corrects (and improves) org-mode's native fontification.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ A comprehensive configuration example:
 ;; Enable custom neotree theme (all-the-icons must be installed!)
 (doom-themes-neotree-config)
 ;; or for treemacs users
-(doom-themes-treemacs-color-icons t) ;; set to t for a more colorful less minimalistic Treemacs theme
+(setq doom-themes-treemacs-theme "doom-colors") ; use the colorful treemacs theme
 (doom-themes-treemacs-config)
 
 ;; Corrects (and improves) org-mode's native fontification.

--- a/doom-themes-ext-treemacs.el
+++ b/doom-themes-ext-treemacs.el
@@ -19,6 +19,10 @@ variable-pitch face."
   :type 'integer
   :group 'doom-themes-treemacs)
 
+(defcustom doom-themes-treemacs-color-icons nil
+  "If non nil, display a lesss miimalistic Treemacs theme with colorful icons."
+  :type 'boolean
+  :group 'doom-themes-treemacs)
 
 ;;
 ;;; Library
@@ -94,81 +98,310 @@ variable-pitch face."
   (treemacs-create-theme "doom"
     :config
     (let ((face-spec '(:inherit font-lock-doc-face :slant normal)))
-      (treemacs-create-icon
-       :icon (format " %s\t" (all-the-icons-octicon "repo" :v-adjust -0.1 :face face-spec))
-       :extensions (root))
-      (treemacs-create-icon
-       :icon (format "%s\t%s\t"
-                     (all-the-icons-octicon "chevron-down" :height 0.75 :v-adjust 0.1 :face face-spec)
-                     (all-the-icons-octicon "file-directory" :v-adjust 0 :face face-spec))
-       :extensions (dir-open))
-      (treemacs-create-icon
-       :icon (format "%s\t%s\t"
-                     (all-the-icons-octicon "chevron-right" :height 0.75 :v-adjust 0.1 :face face-spec)
-                     (all-the-icons-octicon "file-directory" :v-adjust 0 :face face-spec))
-       :extensions (dir-closed))
-      (treemacs-create-icon
-       :icon (format "%s\t%s\t"
-                     (all-the-icons-octicon "chevron-down" :height 0.75 :v-adjust 0.1 :face face-spec)
-                     (all-the-icons-octicon "package" :v-adjust 0 :face face-spec)) :extensions (tag-open))
-      (treemacs-create-icon
-       :icon (format "%s\t%s\t"
-                     (all-the-icons-octicon "chevron-right" :height 0.75 :v-adjust 0.1 :face face-spec)
-                     (all-the-icons-octicon "package" :v-adjust 0 :face face-spec))
-       :extensions (tag-closed))
-      (treemacs-create-icon
-       :icon (format "%s\t" (all-the-icons-octicon "tag" :height 0.9 :v-adjust 0 :face face-spec))
-       :extensions (tag-leaf))
-      (treemacs-create-icon
-       :icon (format "%s\t" (all-the-icons-octicon "flame" :v-adjust 0 :face face-spec))
-       :extensions (error))
-      (treemacs-create-icon
-       :icon (format "%s\t" (all-the-icons-octicon "stop" :v-adjust 0 :face face-spec))
-       :extensions (warning))
-      (treemacs-create-icon
-       :icon (format "%s\t" (all-the-icons-octicon "info" :height 0.75 :v-adjust 0.1 :face face-spec))
-       :extensions (info))
-      (treemacs-create-icon
-       :icon (format "  %s\t" (all-the-icons-octicon "file-media" :v-adjust 0 :face face-spec))
-       :extensions ("png" "jpg" "jpeg" "gif" "ico" "tif" "tiff" "svg" "bmp"
-                    "psd" "ai" "eps" "indd" "mov" "avi" "mp4" "webm" "mkv"
-                    "wav" "mp3" "ogg" "midi"))
-      (treemacs-create-icon
-       :icon (format "  %s\t" (all-the-icons-octicon "file-code" :v-adjust 0 :face face-spec))
-       :extensions ("yml" "yaml" "sh" "zsh" "fish" "c" "h" "cpp" "cxx" "hpp"
-                    "tpp" "cc" "hh" "hs" "lhs" "cabal" "py" "pyc" "rs" "el"
-                    "elc" "clj" "cljs" "cljc" "ts" "tsx" "vue" "css" "html"
-                    "htm" "dart" "java" "kt" "scala" "sbt" "go" "js" "jsx"
-                    "hy" "json" "jl" "ex" "exs" "eex" "ml" "mli" "pp" "dockerfile"
-                    "vagrantfile" "j2" "jinja2" "tex" "racket" "rkt" "rktl" "rktd"
-                    "scrbl" "scribble" "plt" "makefile" "elm" "xml" "xsl" "rb"
-                    "scss" "lua" "lisp" "scm" "sql" "toml" "nim" "pl" "pm" "perl"
-                    "vimrc" "tridactylrc" "vimperatorrc" "ideavimrc" "vrapperrc"
-                    "cask" "r" "re" "rei" "bashrc" "zshrc" "inputrc" "editorconfig"
-                    "gitconfig"))
-      (treemacs-create-icon
-       :icon (format "  %s\t" (all-the-icons-octicon "book" :v-adjust 0 :face face-spec))
-       :extensions ("lrf" "lrx" "cbr" "cbz" "cb7" "cbt" "cba" "chm" "djvu"
-                    "doc" "docx" "pdb" "pdb" "fb2" "xeb" "ceb" "inf" "azw"
-                    "azw3" "kf8" "kfx" "lit" "prc" "mobi" "exe" "or" "html"
-                    "pkg" "opf" "txt" "pdb" "ps" "rtf" "pdg" "xml" "tr2"
-                    "tr3" "oxps" "xps"))
-      (treemacs-create-icon
-       :icon (format "  %s\t" (all-the-icons-octicon "file-text" :v-adjust 0 :face face-spec))
-       :extensions ("md" "markdown" "rst" "log" "org" "txt"
-                    "CONTRIBUTE" "LICENSE" "README" "CHANGELOG"))
-      (treemacs-create-icon
-       :icon (format "  %s\t" (all-the-icons-octicon "file-binary" :v-adjust 0 :face face-spec))
-       :extensions ("exe" "dll" "obj" "so" "o" "out"))
-      (treemacs-create-icon
-       :icon (format "  %s\t" (all-the-icons-octicon "file-pdf" :v-adjust 0 :face face-spec))
-       :extensions ("pdf"))
-      (treemacs-create-icon
-       :icon (format "  %s\t" (all-the-icons-octicon "file-zip" :v-adjust 0 :face face-spec))
-       :extensions ("zip" "7z" "tar" "gz" "rar" "tgz"))
-      (treemacs-create-icon
-       :icon (format "  %s\t" (all-the-icons-octicon "file-text" :v-adjust 0 :face face-spec))
-       :extensions (fallback))))
+      (if doom-themes-treemacs-color-icons
+	  ;; if `doom-themes-treemacs-color-icons' is non-nil, display a more colorful Treemacs theme.
+	  (progn
+	    (treemacs-create-icon
+	     :icon (format " %s\t" (all-the-icons-octicon "repo" :v-adjust -0.1 :face face-spec))
+	     :extensions (root))
+	    (treemacs-create-icon
+	     :icon (format "%s\t%s\t"
+			   (all-the-icons-octicon "chevron-down" :height 0.75 :v-adjust 0.1 :face face-spec)
+			   (all-the-icons-octicon "file-directory" :v-adjust 0 :face face-spec))
+	     :extensions (dir-open))
+	    (treemacs-create-icon
+	     :icon (format "%s\t%s\t"
+			   (all-the-icons-octicon "chevron-right" :height 0.75 :v-adjust 0.1 :face face-spec)
+			   (all-the-icons-octicon "file-directory" :v-adjust 0 :face face-spec))
+	     :extensions (dir-closed))
+	    (treemacs-create-icon
+	     :icon (format "%s\t%s\t"
+			   (all-the-icons-octicon "chevron-down" :height 0.75 :v-adjust 0.1 :face face-spec)
+			   (all-the-icons-faicon "cube"
+						 :v-adjust 0.1
+						 :face 'font-lock-keyword-face))
+	     :extensions (tag-open))
+	    (treemacs-create-icon
+	     :icon (format "%s\t%s\t"
+			   (all-the-icons-octicon "chevron-right" :height 0.75 :v-adjust 0.1 :face face-spec)
+			   (all-the-icons-faicon "cube"
+						 :v-adjust 0.1
+						 :face 'font-lock-keyword-face))
+	     :extensions (tag-closed))
+	    (treemacs-create-icon
+	     :icon (format "%s " (all-the-icons-faicon "tag"
+						       :height 0.9
+						       :face 'font-lock-type-face))
+	     :extensions (tag-leaf))
+	    (treemacs-create-icon
+	     :icon (format "%s\t" (all-the-icons-octicon "flame" :v-adjust 0 :face face-spec))
+	     :extensions (error))
+	    (treemacs-create-icon
+	     :icon (format "%s\t" (all-the-icons-octicon "stop" :v-adjust 0 :face face-spec))
+	     :extensions (warning))
+	    (treemacs-create-icon
+	     :icon (format "%s\t" (all-the-icons-octicon "info" :height 0.75 :v-adjust 0.1 :face face-spec))
+	     :extensions (info))
+	    ;; Icons for filetypes
+	    (treemacs-create-icon
+	     :icon (format " %s " (all-the-icons-icon-for-file "foo.cs"))
+	     :extensions ("cs"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-icon-for-file "fo.css"))
+	     :extensions ("css"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.git"))
+	     :extensions ("gitignore" "git" "gitconfig" "gitmodules"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.html"))
+	     :extensions ("html" "htm"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.java"))
+	     :extensions ("java"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.py"))
+	     :extensions ("py"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.rs"))
+	     :extensions ("rs"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.hs"))
+	     :extensions ("hs"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.c"))
+	     :extensions ("c" "h"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.cpp"))
+	     :extensions ("cpp" "cxx" "hpp" "tpp" "cc" "hh"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.rb"))
+	     :extensions ("rb"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.scala"))
+	     :extensions ("scala"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.ex"))
+	     :extensions ("ex" "exs"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.erl"))
+	     :extensions ("erl" "hrl")) ;
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.clj"))
+	     :extensions ("clj" "cljs" "cljc"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-fileicon "cabal" :face face-spec))
+	     :extensions ("cabal"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.lisp"))
+	     :extensions ("lisp"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.go"))
+	     :extensions ("go"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.el"))
+	     :extensions ("el" "elc"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.jl"))
+	     :extensions ("jl"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-fileicon "kotlin" :face face-spec))
+	     :extensions ("kt" "kts"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.hy"))
+	     :extensions ("hy"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.js"))
+	     :extensions ("js"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.jsx"))
+	     :extensions ("jsx"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.ml"))
+	     :extensions ("ml" "mli"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.org"))
+	     :extensions ("org"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.php"))
+	     :extensions ("php"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.sh"))
+	     :extensions ("sh"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.zsh"))
+	     :extensions ("zsh"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.fish"))
+	     :extensions ("fish"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.ts"))
+	     :extensions ("ts"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-fileicon "nimrod" :face face-spec))
+	     :extensions ("nim" "nims"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.pl"))
+	     :extensions ("pl" "pm" "perl"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-fileicon "perl6" :face face-spec))
+	     :extensions ("pm6"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.r"))
+	     :extensions ("r"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.tex"))
+	     :extensions ("tex"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.rst"))
+	     :extensions ("rst"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.vue"))
+	     :extensions ("vue"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.md"))
+	     :extensions ("md" "markdown"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.pdf"))
+	     :extensions ("pdf"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.csv"))
+	     :extensions ("csv"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-octicon "database" :face face-spec))
+	     :extensions ("sql"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-material "style" :face face-spec))
+	     :extensions ("styles"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-fileicon "lua" :face face-spec))
+	     :extensions ("lua"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-fileicon "asciidoc" :face face-spec))
+	     :extensions ("adoc" "asciidoc"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.sbt"))
+	     :extensions ("sbt"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-fileicon "puppet" :face face-spec))
+	     :extensions ("pp"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-fileicon "jinja" :face face-spec))
+	     :extensions ("j2" "jinja2"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-fileicon "dockerfile" :face face-spec))
+	     :extensions ("dockerfile"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-fileicon "vagrant" :face face-spec))
+	     :extensions ("vagrantfile"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.rkt"))
+	     :extensions ("racket" "rkt" "rktl" "rktd" "scrbl" "scribble" "plt"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.reason"))
+	     :extensions ("re" "rei"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-fileicon "verilog" :face 'all-the-icons-red))
+	     :extensions ("v" "vh" "sv"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-octicon "file-media" :v-adjust 0 :face face-spec))
+	     :extensions ("png" "jpg" "jpeg" "gif" "ico" "tif" "tiff" "svg" "bmp"
+			  "psd" "ai" "eps" "indd" "mov" "avi" "mp4" "webm" "mkv"
+			  "wav" "mp3" "ogg" "midi"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-octicon "book" :v-adjust 0 :face face-spec))
+	     :extensions ("lrf" "lrx" "cbr" "cbz" "cb7" "cbt" "cba" "chm" "djvu"
+			  "doc" "docx" "pdb" "pdb" "fb2" "xeb" "ceb" "inf" "azw"
+			  "azw3" "kf8" "kfx" "lit" "prc" "mobi" "exe" "or"
+			  "pkg" "opf" "txt" "pdb" "ps" "rtf" "pdg" "xml" "tr2"
+			  "tr3" "oxps" "xps"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-octicon "file-text" :v-adjust 0 :face face-spec))
+	     :extensions ("txt" "CONTRIBUTE" "LICENSE" "README" "CHANGELOG"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-octicon "file-binary" :v-adjust 0 :face face-spec))
+	     :extensions ("exe" "dll" "obj" "so" "o" "out"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-octicon "file-zip" :v-adjust 0 :face face-spec))
+	     :extensions ("zip" "7z" "tar" "gz" "rar" "tgz"))
+	    (treemacs-create-icon
+	     :icon (format "  %s\t" (all-the-icons-octicon "file-text" :v-adjust 0 :face face-spec))
+	     :extensions (fallback)))
+	;; else, display a minimalistic Atom-esque theme
+	(treemacs-create-icon
+	 :icon (format " %s\t" (all-the-icons-octicon "repo" :v-adjust -0.1 :face face-spec))
+	 :extensions (root))
+	(treemacs-create-icon
+	 :icon (format "%s\t%s\t"
+		       (all-the-icons-octicon "chevron-down" :height 0.75 :v-adjust 0.1 :face face-spec)
+		       (all-the-icons-octicon "file-directory" :v-adjust 0 :face face-spec))
+	 :extensions (dir-open))
+	(treemacs-create-icon
+	 :icon (format "%s\t%s\t"
+		       (all-the-icons-octicon "chevron-right" :height 0.75 :v-adjust 0.1 :face face-spec)
+		       (all-the-icons-octicon "file-directory" :v-adjust 0 :face face-spec))
+	 :extensions (dir-closed))
+	(treemacs-create-icon
+	 :icon (format "%s\t%s\t"
+		       (all-the-icons-octicon "chevron-down" :height 0.75 :v-adjust 0.1 :face face-spec)
+		       (all-the-icons-octicon "package" :v-adjust 0 :face face-spec)) :extensions (tag-open))
+	(treemacs-create-icon
+	 :icon (format "%s\t%s\t"
+		       (all-the-icons-octicon "chevron-right" :height 0.75 :v-adjust 0.1 :face face-spec)
+		       (all-the-icons-octicon "package" :v-adjust 0 :face face-spec))
+	 :extensions (tag-closed))
+	(treemacs-create-icon
+	 :icon (format "%s\t" (all-the-icons-octicon "tag" :height 0.9 :v-adjust 0 :face face-spec))
+	 :extensions (tag-leaf))
+	(treemacs-create-icon
+	 :icon (format "%s\t" (all-the-icons-octicon "flame" :v-adjust 0 :face face-spec))
+	 :extensions (error))
+	(treemacs-create-icon
+	 :icon (format "%s\t" (all-the-icons-octicon "stop" :v-adjust 0 :face face-spec))
+	 :extensions (warning))
+	(treemacs-create-icon
+	 :icon (format "%s\t" (all-the-icons-octicon "info" :height 0.75 :v-adjust 0.1 :face face-spec))
+	 :extensions (info))
+	(treemacs-create-icon
+	 :icon (format "  %s\t" (all-the-icons-octicon "file-media" :v-adjust 0 :face face-spec))
+	 :extensions ("png" "jpg" "jpeg" "gif" "ico" "tif" "tiff" "svg" "bmp"
+		      "psd" "ai" "eps" "indd" "mov" "avi" "mp4" "webm" "mkv"
+		      "wav" "mp3" "ogg" "midi"))
+	(treemacs-create-icon
+	 :icon (format "  %s\t" (all-the-icons-octicon "file-code" :v-adjust 0 :face face-spec))
+	 :extensions ("yml" "yaml" "sh" "zsh" "fish" "c" "h" "cpp" "cxx" "hpp"
+		      "tpp" "cc" "hh" "hs" "lhs" "cabal" "py" "pyc" "rs" "el"
+		      "elc" "clj" "cljs" "cljc" "ts" "tsx" "vue" "css" "html"
+		      "htm" "dart" "java" "kt" "scala" "sbt" "go" "js" "jsx"
+		      "hy" "json" "jl" "ex" "exs" "eex" "ml" "mli" "pp" "dockerfile"
+		      "vagrantfile" "j2" "jinja2" "tex" "racket" "rkt" "rktl" "rktd"
+		      "scrbl" "scribble" "plt" "makefile" "elm" "xml" "xsl" "rb"
+		      "scss" "lua" "lisp" "scm" "sql" "toml" "nim" "pl" "pm" "perl"
+		      "vimrc" "tridactylrc" "vimperatorrc" "ideavimrc" "vrapperrc"
+		      "cask" "r" "re" "rei" "bashrc" "zshrc" "inputrc" "editorconfig"
+		      "gitconfig"))
+	(treemacs-create-icon
+	 :icon (format "  %s\t" (all-the-icons-octicon "book" :v-adjust 0 :face face-spec))
+	 :extensions ("lrf" "lrx" "cbr" "cbz" "cb7" "cbt" "cba" "chm" "djvu"
+		      "doc" "docx" "pdb" "pdb" "fb2" "xeb" "ceb" "inf" "azw"
+		      "azw3" "kf8" "kfx" "lit" "prc" "mobi" "exe" "or" "html"
+		      "pkg" "opf" "txt" "pdb" "ps" "rtf" "pdg" "xml" "tr2"
+		      "tr3" "oxps" "xps"))
+	(treemacs-create-icon
+	 :icon (format "  %s\t" (all-the-icons-octicon "file-text" :v-adjust 0 :face face-spec))
+	 :extensions ("md" "markdown" "rst" "log" "org" "txt"
+		      "CONTRIBUTE" "LICENSE" "README" "CHANGELOG"))
+	(treemacs-create-icon
+	 :icon (format "  %s\t" (all-the-icons-octicon "file-binary" :v-adjust 0 :face face-spec))
+	 :extensions ("exe" "dll" "obj" "so" "o" "out"))
+	(treemacs-create-icon
+	 :icon (format "  %s\t" (all-the-icons-octicon "file-pdf" :v-adjust 0 :face face-spec))
+	 :extensions ("pdf"))
+	(treemacs-create-icon
+	 :icon (format "  %s\t" (all-the-icons-octicon "file-zip" :v-adjust 0 :face face-spec))
+	 :extensions ("zip" "7z" "tar" "gz" "rar" "tgz"))
+	(treemacs-create-icon
+	 :icon (format "  %s\t" (all-the-icons-octicon "file-text" :v-adjust 0 :face face-spec))
+	 :extensions (fallback)))))
 
   (treemacs-load-theme "doom"))
 

--- a/doom-themes-ext-treemacs.el
+++ b/doom-themes-ext-treemacs.el
@@ -273,6 +273,9 @@ This is used to generate extensions for `treemacs' from `all-the-icons-icon-alis
         (treemacs-create-icon
          :icon (format "  %s\t" (all-the-icons-fileicon "verilog" :face 'all-the-icons-red))
          :extensions ("v" "vh" "sv"))
+        (treemacs-create-icon
+         :icon (format "  %s\t" (all-the-icons-alltheicon "git" :face 'all-the-icons-red))
+         :extensions ("gitignore" "git" "gitconfig" "gitmodules"))
 
         (dolist (item all-the-icons-icon-alist)
           (let* ((extensions (doom-themes--get-treemacs-extensions (car item)))

--- a/doom-themes-ext-treemacs.el
+++ b/doom-themes-ext-treemacs.el
@@ -93,243 +93,25 @@ variable-pitch face."
   ;; variable-pitch labels for files/folders
   (doom-themes-enable-treemacs-variable-pitch-labels)
   (advice-add #'load-theme :after #'doom-themes-enable-treemacs-variable-pitch-labels)
-
+  
   ;; minimalistic atom-inspired icon theme
-  (treemacs-create-theme "doom"
-    :config
-    (let ((face-spec '(:inherit font-lock-doc-face :slant normal)))
-      (treemacs-create-icon
-       :icon (format " %s\t" (all-the-icons-octicon "repo" :v-adjust -0.1 :face face-spec))
-       :extensions (root))
-      (treemacs-create-icon
-       :icon (format "%s\t%s\t"
-                     (all-the-icons-octicon "chevron-down" :height 0.75 :v-adjust 0.1 :face face-spec)
-                     (all-the-icons-octicon "file-directory" :v-adjust 0 :face face-spec))
-       :extensions (dir-open))
-      (treemacs-create-icon
-       :icon (format "%s\t%s\t"
-                     (all-the-icons-octicon "chevron-right" :height 0.75 :v-adjust 0.1 :face face-spec)
-                     (all-the-icons-octicon "file-directory" :v-adjust 0 :face face-spec))
-       :extensions (dir-closed))
-      (treemacs-create-icon
-       :icon (format "  %s\t" (all-the-icons-octicon "file-media" :v-adjust 0 :face face-spec))
-       :extensions ("png" "jpg" "jpeg" "gif" "ico" "tif" "tiff" "svg" "bmp"
-                    "psd" "ai" "eps" "indd" "mov" "avi" "mp4" "webm" "mkv"
-                    "wav" "mp3" "ogg" "midi"))
-      (treemacs-create-icon
-       :icon (format "  %s\t" (all-the-icons-octicon "file-binary" :v-adjust 0 :face face-spec))
-       :extensions ("exe" "dll" "obj" "so" "o" "out"))
-      (treemacs-create-icon
-       :icon (format "  %s\t" (all-the-icons-octicon "file-zip" :v-adjust 0 :face face-spec))
-       :extensions ("zip" "7z" "tar" "gz" "rar" "tgz"))
-      (treemacs-create-icon
-       :icon (format "  %s\t" (all-the-icons-octicon "book" :v-adjust 0 :face face-spec))
-       :extensions ("lrf" "lrx" "cbr" "cbz" "cb7" "cbt" "cba" "chm" "djvu"
-                    "doc" "docx" "pdb" "pdb" "fb2" "xeb" "ceb" "inf" "azw"
-                    "azw3" "kf8" "kfx" "lit" "prc" "mobi" "exe" "or" "pkg"
-                    "opf" "txt" "pdb" "ps" "rtf" "pdg" "xml" "tr2" "tr3"
-                    "oxps" "xps"))
-      (treemacs-create-icon
-       :icon (format "  %s\t" (all-the-icons-octicon "file-text" :v-adjust 0 :face face-spec))
-       :extensions (fallback))
-      (if doom-themes-treemacs-color-icons
-          ;; if `doom-themes-treemacs-color-icons' is non-nil, display a more colorful Treemacs theme.
-          (progn
-            (treemacs-create-icon
-             :icon (format "%s\t%s\t"
-                           (all-the-icons-octicon "chevron-down" :height 0.75 :v-adjust 0.1 :face face-spec)
-                           (all-the-icons-faicon "cube"
-                                                 :v-adjust 0.1
-                                                 :face 'font-lock-function-name-face))
-             :extensions (tag-open))
-            (treemacs-create-icon
-             :icon (format "%s\t%s\t"
-                           (all-the-icons-octicon "chevron-right" :height 0.75 :v-adjust 0.1 :face face-spec)
-                           (all-the-icons-faicon "cube"
-                                                 :v-adjust 0.1
-                                                 :face 'font-lock-function-name-face))
-             :extensions (tag-closed))
-            (treemacs-create-icon
-             :icon (format "%s " (all-the-icons-faicon "tag"
-                                                       :height 0.9
-                                                       :face 'font-lock-variable-name-face))
-             :extensions (tag-leaf))
-            (treemacs-create-icon
-             :icon (format "%s\t" (all-the-icons-octicon "flame" :v-adjust 0 :face 'all-the-icons-red))
-             :extensions (error))
-            (treemacs-create-icon
-             :icon (format "%s\t" (all-the-icons-octicon "stop" :v-adjust 0 :face 'all-the-icons-yellow))
-             :extensions (warning))
-            (treemacs-create-icon
-             :icon (format "%s\t" (all-the-icons-octicon "info" :height 0.75 :v-adjust 0.1 :face 'all-the-icons-green))
-             :extensions (info))
-            ;; Icons for filetypes
-            (treemacs-create-icon
-             :icon (format " %s " (all-the-icons-icon-for-file "foo.cs"))
-             :extensions ("cs"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-icon-for-file "fo.css"))
-             :extensions ("css"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.git"))
-             :extensions ("gitignore" "git" "gitconfig" "gitmodules"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.html"))
-             :extensions ("html" "htm"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.java"))
-             :extensions ("java"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.py"))
-             :extensions ("py"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.rs"))
-             :extensions ("rs"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.hs"))
-             :extensions ("hs"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.c"))
-             :extensions ("c" "h"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.cpp"))
-             :extensions ("cpp" "cxx" "hpp" "tpp" "cc" "hh"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.rb"))
-             :extensions ("rb"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.scala"))
-             :extensions ("scala"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.ex"))
-             :extensions ("ex" "exs"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.erl"))
-             :extensions ("erl" "hrl")) ;
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.clj"))
-             :extensions ("clj" "cljs" "cljc"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-fileicon "cabal" :face face-spec))
-             :extensions ("cabal"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.lisp"))
-             :extensions ("lisp"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.go"))
-             :extensions ("go"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.el"))
-             :extensions ("el" "elc"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.jl"))
-             :extensions ("jl"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-fileicon "kotlin" :face face-spec))
-             :extensions ("kt" "kts"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.hy"))
-             :extensions ("hy"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.js"))
-             :extensions ("js"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.jsx"))
-             :extensions ("jsx"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.ml"))
-             :extensions ("ml" "mli"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.org"))
-             :extensions ("org"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.php"))
-             :extensions ("php"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.sh"))
-             :extensions ("sh"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.zsh"))
-             :extensions ("zsh"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.fish"))
-             :extensions ("fish"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.ts"))
-             :extensions ("ts"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-fileicon "nimrod" :face face-spec))
-             :extensions ("nim" "nims"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.pl"))
-             :extensions ("pl" "pm" "perl"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-fileicon "perl6" :face face-spec))
-             :extensions ("pm6"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.r"))
-             :extensions ("r"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.tex"))
-             :extensions ("tex"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.rst"))
-             :extensions ("rst"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.vue"))
-             :extensions ("vue"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.md"))
-             :extensions ("md" "markdown"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.pdf"))
-             :extensions ("pdf"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.csv"))
-             :extensions ("csv"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-octicon "database" :face face-spec))
-             :extensions ("sql"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-material "style" :face face-spec))
-             :extensions ("styles"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-fileicon "lua" :face face-spec))
-             :extensions ("lua"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-fileicon "asciidoc" :face face-spec))
-             :extensions ("adoc" "asciidoc"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.sbt"))
-             :extensions ("sbt"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-fileicon "puppet" :face face-spec))
-             :extensions ("pp"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-fileicon "jinja" :face face-spec))
-             :extensions ("j2" "jinja2"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-fileicon "dockerfile" :face face-spec))
-             :extensions ("dockerfile"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-fileicon "vagrant" :face face-spec))
-             :extensions ("vagrantfile"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.rkt"))
-             :extensions ("racket" "rkt" "rktl" "rktd" "scrbl" "scribble" "plt"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.reason"))
-             :extensions ("re" "rei"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-fileicon "verilog" :face 'all-the-icons-red))
-             :extensions ("v" "vh" "sv"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.log"))
-             :extensions ("log"))
-            (treemacs-create-icon
-             :icon (format "  %s\t" (all-the-icons-octicon "file-text" :v-adjust 0 :face face-spec))
-             :extensions ("txt" "CONTRIBUTE" "LICENSE" "README" "CHANGELOG")))
-        ;; else, display a minimalistic Atom-esque theme
+  (let ((face-spec '(:inherit font-lock-doc-face :slant normal)))
+    (treemacs-create-theme "doom"
+      :config
+      (progn
+        (treemacs-create-icon
+         :icon (format " %s\t" (all-the-icons-octicon "repo" :v-adjust -0.1 :face face-spec))
+         :extensions (root))
+        (treemacs-create-icon
+         :icon (format "%s\t%s\t"
+                       (all-the-icons-octicon "chevron-down" :height 0.75 :v-adjust 0.1 :face face-spec)
+                       (all-the-icons-octicon "file-directory" :v-adjust 0 :face face-spec))
+         :extensions (dir-open))
+        (treemacs-create-icon
+         :icon (format "%s\t%s\t"
+                       (all-the-icons-octicon "chevron-right" :height 0.75 :v-adjust 0.1 :face face-spec)
+                       (all-the-icons-octicon "file-directory" :v-adjust 0 :face face-spec))
+         :extensions (dir-closed))
         (treemacs-create-icon
          :icon (format "%s\t%s\t"
                        (all-the-icons-octicon "chevron-down" :height 0.75 :v-adjust 0.1 :face face-spec)
@@ -352,6 +134,11 @@ variable-pitch face."
          :icon (format "%s\t" (all-the-icons-octicon "info" :height 0.75 :v-adjust 0.1 :face face-spec))
          :extensions (info))
         (treemacs-create-icon
+         :icon (format "  %s\t" (all-the-icons-octicon "file-media" :v-adjust 0 :face face-spec))
+         :extensions ("png" "jpg" "jpeg" "gif" "ico" "tif" "tiff" "svg" "bmp"
+                      "psd" "ai" "eps" "indd" "mov" "avi" "mp4" "webm" "mkv"
+                      "wav" "mp3" "ogg" "midi"))
+        (treemacs-create-icon
          :icon (format "  %s\t" (all-the-icons-octicon "file-code" :v-adjust 0 :face face-spec))
          :extensions ("yml" "yaml" "sh" "zsh" "fish" "c" "h" "cpp" "cxx" "hpp"
                       "tpp" "cc" "hh" "hs" "lhs" "cabal" "py" "pyc" "rs" "el"
@@ -363,19 +150,150 @@ variable-pitch face."
                       "scss" "lua" "lisp" "scm" "sql" "toml" "nim" "pl" "pm" "perl"
                       "vimrc" "tridactylrc" "vimperatorrc" "ideavimrc" "vrapperrc"
                       "cask" "r" "re" "rei" "bashrc" "zshrc" "inputrc" "editorconfig"
-                      "gitconfig"))
+                      "gitconfig" "csv" "cabal" "kt" "kts" "nim" "nims" "pm6" "sql"
+                      "styles" "lua" "adoc" "asciidoc" "pp" "j2" "jinja2" "dockerfile"
+                      "vagrantfile" "v" "vh" "sv"))
         (treemacs-create-icon
          :icon (format "  %s\t" (all-the-icons-octicon "book" :v-adjust 0 :face face-spec))
-         :extensions ("html"))
+         :extensions ("lrf" "lrx" "cbr" "cbz" "cb7" "cbt" "cba" "chm" "djvu"
+                      "doc" "docx" "pdb" "pdb" "fb2" "xeb" "ceb" "inf" "azw"
+                      "azw3" "kf8" "kfx" "lit" "prc" "mobi" "exe" "or" "html"
+                      "pkg" "opf" "txt" "pdb" "ps" "rtf" "pdg" "xml" "tr2"
+                      "tr3" "oxps" "xps"))
         (treemacs-create-icon
          :icon (format "  %s\t" (all-the-icons-octicon "file-text" :v-adjust 0 :face face-spec))
          :extensions ("md" "markdown" "rst" "log" "org" "txt"
                       "CONTRIBUTE" "LICENSE" "README" "CHANGELOG"))
         (treemacs-create-icon
+         :icon (format "  %s\t" (all-the-icons-octicon "file-binary" :v-adjust 0 :face face-spec))
+         :extensions ("exe" "dll" "obj" "so" "o" "out"))
+        (treemacs-create-icon
          :icon (format "  %s\t" (all-the-icons-octicon "file-pdf" :v-adjust 0 :face face-spec))
-         :extensions ("pdf")))))
+         :extensions ("pdf"))
+        (treemacs-create-icon
+         :icon (format "  %s\t" (all-the-icons-octicon "file-zip" :v-adjust 0 :face face-spec))
+         :extensions ("zip" "7z" "tar" "gz" "rar" "tgz"))
+        (treemacs-create-icon
+         :icon (format "  %s\t" (all-the-icons-octicon "file-text" :v-adjust 0 :face face-spec))
+         :extensions (fallback))))
 
-  (treemacs-load-theme "doom"))
+    (treemacs-create-theme "doom-colors"
+      :extends "doom"
+      :config
+      (progn
+        (treemacs-create-icon
+         :icon (format "%s\t%s\t"
+                       (all-the-icons-octicon "chevron-down" :height 0.75 :v-adjust 0.1 :face face-spec)
+                       (all-the-icons-faicon "cube"
+                                             :v-adjust 0.1
+                                             :face 'all-the-icons-purple))
+         :extensions (tag-open))
+        (treemacs-create-icon
+         :icon (format "%s\t%s\t"
+                       (all-the-icons-octicon "chevron-right" :height 0.75 :v-adjust 0.1 :face face-spec)
+                       (all-the-icons-faicon "cube"
+                                             :v-adjust 0.1
+                                             :face 'all-the-icons-purple))
+         :extensions (tag-closed))
+        (treemacs-create-icon
+         :icon (format "%s " (all-the-icons-faicon "tag"
+                                                   :height 0.9
+                                                   :face 'all-the-icons-lblue))
+         :extensions (tag-leaf))
+        (treemacs-create-icon
+         :icon (format "%s\t" (all-the-icons-octicon "flame" :v-adjust 0 :face 'all-the-icons-red))
+         :extensions (error))
+        (treemacs-create-icon
+         :icon (format "%s\t" (all-the-icons-octicon "stop" :v-adjust 0 :face 'all-the-icons-yellow))
+         :extensions (warning))
+        (treemacs-create-icon
+         :icon (format "%s\t" (all-the-icons-octicon "info" :height 0.75 :v-adjust 0.1 :face 'all-the-icons-green))
+         :extensions (info))
+        (treemacs-create-icon
+         :icon (format "  %s\t" (all-the-icons-fileicon "cabal" :face 'all-the-icons-lblue))
+         :extensions ("cabal"))
+        (treemacs-create-icon
+         :icon (format "  %s\t" (all-the-icons-fileicon "kotlin" :face 'all-the-icons-orange))
+         :extensions ("kt" "kts"))
+        (treemacs-create-icon
+         :icon (format "  %s\t" (all-the-icons-fileicon "nimrod" :face 'all-the-icons-yellow))
+         :extensions ("nim" "nims"))
+        (treemacs-create-icon
+         :icon (format "  %s\t" (all-the-icons-fileicon "perl6" :face 'all-the-icons-pink))
+         :extensions ("pm6"))
+        (treemacs-create-icon
+         :icon (format "  %s\t" (all-the-icons-octicon "database" :face 'all-the-icons-silver))
+         :extensions ("sql"))
+        (treemacs-create-icon
+         :icon (format "  %s\t" (all-the-icons-material "style" :face 'all-the-icons-red))
+         :extensions ("styles"))
+        (treemacs-create-icon
+         :icon (format "  %s\t" (all-the-icons-fileicon "lua" :face 'all-the-icons-dblue))
+         :extensions ("lua"))
+        (treemacs-create-icon
+         :icon (format "  %s\t" (all-the-icons-fileicon "asciidoc" :face 'all-the-icons-lblue))
+         :extensions ("adoc" "asciidoc"))
+        (treemacs-create-icon
+         :icon (format "  %s\t" (all-the-icons-fileicon "puppet" :face 'all-the-icons-yellow))
+         :extensions ("pp"))
+        (treemacs-create-icon
+         :icon (format "  %s\t" (all-the-icons-fileicon "jinja" :face 'all-the-icons-silver))
+         :extensions ("j2" "jinja2"))
+        (treemacs-create-icon
+         :icon (format "  %s\t" (all-the-icons-fileicon "dockerfile" :face 'all-the-icons-cyan))
+         :extensions ("dockerfile"))
+        (treemacs-create-icon
+         :icon (format "  %s\t" (all-the-icons-fileicon "vagrant" :face 'all-the-icons-blue))
+         :extensions ("vagrantfile"))
+        (treemacs-create-icon
+         :icon (format "  %s\t" (all-the-icons-fileicon "verilog" :face 'all-the-icons-red))
+         :extensions ("v" "vh" "sv"))
+
+        (defun get-extenstions (ext)
+          "Transfer EXT regexps to extension list."
+          (let* ((e (s-replace-all
+                     '((".\\?" . "") ("\\?" . "") ("\\." . "")
+                       ("\\" . "") ("^" . "") ("$" . "")
+                       ("'" . "") ("*." . "") ("*" . ""))
+                     ext))
+                 (exts (list e)))
+            ;; Handle "[]"
+            (when-let* ((s (s-split "\\[\\|\\]" e))
+                        (f (car s))
+                        (m (cadr s))
+                        (l (caddr s))
+                        (mcs (delete "" (s-split "" m))))
+              (setq exts nil)
+              (dolist (c mcs)
+                (push (s-concat f c l) exts)))
+            ;; Handle '?
+            (dolist (ext exts)
+              (when (s-match "?" ext)
+                (when-let ((s (s-split "?" ext)))
+                  (setq exts nil)
+                  (push (s-join "" s) exts)
+                  (push (s-concat (if (> (length (car s)) 1)
+                                      (substring (car s) 0 -1))
+                                  (cadr s)) exts))))
+            exts))
+
+        (dolist (item all-the-icons-icon-alist)
+          (let* ((extensions (get-extenstions (car item)))
+                 (func (cadr item))
+                 (args (append (list (caddr item)) '(:v-adjust -0.05) (cdddr item)))
+                 (icon (apply func args)))
+            (let* ((icon-pair (cons (format "  %s\t" icon) " "))
+                   (gui-icons (treemacs-theme->gui-icons treemacs--current-theme))
+                   (tui-icons (treemacs-theme->tui-icons treemacs--current-theme))
+                   (gui-icon  (car icon-pair))
+                   (tui-icon  (cdr icon-pair)))
+              (--each extensions
+                (ht-set! gui-icons it gui-icon)
+                (ht-set! tui-icons it tui-icon))))))))
+
+  (if doom-themes-treemacs-color-icons
+      (treemacs-load-theme "doom-colors")
+    (treemacs-load-theme "doom")))
 
 ;;;###autoload
 (defun doom-themes-treemacs-config ()

--- a/doom-themes-ext-treemacs.el
+++ b/doom-themes-ext-treemacs.el
@@ -20,7 +20,7 @@ variable-pitch face."
   :group 'doom-themes-treemacs)
 
 (defcustom doom-themes-treemacs-color-icons nil
-  "If non nil, display a lesss miimalistic Treemacs theme with colorful icons."
+  "If non nil, display a less minimalistic Treemacs theme with colorful icons."
   :type 'boolean
   :group 'doom-themes-treemacs)
 

--- a/doom-themes-ext-treemacs.el
+++ b/doom-themes-ext-treemacs.el
@@ -98,49 +98,70 @@ variable-pitch face."
   (treemacs-create-theme "doom"
     :config
     (let ((face-spec '(:inherit font-lock-doc-face :slant normal)))
+      (treemacs-create-icon
+       :icon (format " %s\t" (all-the-icons-octicon "repo" :v-adjust -0.1 :face face-spec))
+       :extensions (root))
+      (treemacs-create-icon
+       :icon (format "%s\t%s\t"
+		     (all-the-icons-octicon "chevron-down" :height 0.75 :v-adjust 0.1 :face face-spec)
+		     (all-the-icons-octicon "file-directory" :v-adjust 0 :face face-spec))
+       :extensions (dir-open))
+      (treemacs-create-icon
+       :icon (format "%s\t%s\t"
+		     (all-the-icons-octicon "chevron-right" :height 0.75 :v-adjust 0.1 :face face-spec)
+		     (all-the-icons-octicon "file-directory" :v-adjust 0 :face face-spec))
+       :extensions (dir-closed))
+      (treemacs-create-icon
+       :icon (format "  %s\t" (all-the-icons-octicon "file-media" :v-adjust 0 :face face-spec))
+       :extensions ("png" "jpg" "jpeg" "gif" "ico" "tif" "tiff" "svg" "bmp"
+		    "psd" "ai" "eps" "indd" "mov" "avi" "mp4" "webm" "mkv"
+		    "wav" "mp3" "ogg" "midi"))
+      (treemacs-create-icon
+       :icon (format "  %s\t" (all-the-icons-octicon "file-binary" :v-adjust 0 :face face-spec))
+       :extensions ("exe" "dll" "obj" "so" "o" "out"))
+      (treemacs-create-icon
+       :icon (format "  %s\t" (all-the-icons-octicon "file-zip" :v-adjust 0 :face face-spec))
+       :extensions ("zip" "7z" "tar" "gz" "rar" "tgz"))
+      (treemacs-create-icon
+       :icon (format "  %s\t" (all-the-icons-octicon "book" :v-adjust 0 :face face-spec))
+       :extensions ("lrf" "lrx" "cbr" "cbz" "cb7" "cbt" "cba" "chm" "djvu"
+		    "doc" "docx" "pdb" "pdb" "fb2" "xeb" "ceb" "inf" "azw"
+		    "azw3" "kf8" "kfx" "lit" "prc" "mobi" "exe" "or" "pkg"
+		    "opf" "txt" "pdb" "ps" "rtf" "pdg" "xml" "tr2" "tr3"
+		    "oxps" "xps"))
+      (treemacs-create-icon
+       :icon (format "  %s\t" (all-the-icons-octicon "file-text" :v-adjust 0 :face face-spec))
+       :extensions (fallback))
       (if doom-themes-treemacs-color-icons
 	  ;; if `doom-themes-treemacs-color-icons' is non-nil, display a more colorful Treemacs theme.
 	  (progn
-	    (treemacs-create-icon
-	     :icon (format " %s\t" (all-the-icons-octicon "repo" :v-adjust -0.1 :face face-spec))
-	     :extensions (root))
-	    (treemacs-create-icon
-	     :icon (format "%s\t%s\t"
-			   (all-the-icons-octicon "chevron-down" :height 0.75 :v-adjust 0.1 :face face-spec)
-			   (all-the-icons-octicon "file-directory" :v-adjust 0 :face face-spec))
-	     :extensions (dir-open))
-	    (treemacs-create-icon
-	     :icon (format "%s\t%s\t"
-			   (all-the-icons-octicon "chevron-right" :height 0.75 :v-adjust 0.1 :face face-spec)
-			   (all-the-icons-octicon "file-directory" :v-adjust 0 :face face-spec))
-	     :extensions (dir-closed))
 	    (treemacs-create-icon
 	     :icon (format "%s\t%s\t"
 			   (all-the-icons-octicon "chevron-down" :height 0.75 :v-adjust 0.1 :face face-spec)
 			   (all-the-icons-faicon "cube"
 						 :v-adjust 0.1
-						 :face 'font-lock-keyword-face))
+						 :face 'font-lock-function-name-face))
 	     :extensions (tag-open))
 	    (treemacs-create-icon
 	     :icon (format "%s\t%s\t"
 			   (all-the-icons-octicon "chevron-right" :height 0.75 :v-adjust 0.1 :face face-spec)
 			   (all-the-icons-faicon "cube"
 						 :v-adjust 0.1
-						 :face 'font-lock-keyword-face))
+						 :face 'font-lock-function-name-face))
 	     :extensions (tag-closed))
 	    (treemacs-create-icon
 	     :icon (format "%s " (all-the-icons-faicon "tag"
 						       :height 0.9
-						       :face 'font-lock-type-face))
+						       :face 'font-lock-variable-name-face))
 	     :extensions (tag-leaf))
 	    (treemacs-create-icon
-	     :icon (format "%s\t" (all-the-icons-octicon "flame" :v-adjust 0 :face face-spec))
+	     :icon (format "%s\t" (all-the-icons-octicon "flame" :v-adjust 0 :face 'all-the-icons-red))
 	     :extensions (error))
 	    (treemacs-create-icon
-	     :icon (format "%s\t" (all-the-icons-octicon "stop" :v-adjust 0 :face face-spec))
+	     :icon (format "%s\t" (all-the-icons-octicon "stop" :v-adjust 0 :face 'all-the-icons-yellow))
 	     :extensions (warning))
 	    (treemacs-create-icon
-	     :icon (format "%s\t" (all-the-icons-octicon "info" :height 0.75 :v-adjust 0.1 :face face-spec))
+	     :icon (format "%s\t" (all-the-icons-octicon "info" :height 0.75 :v-adjust 0.1 :face 'all-the-icons-green))
 	     :extensions (info))
 	    ;; Icons for filetypes
 	    (treemacs-create-icon
@@ -303,43 +324,12 @@ variable-pitch face."
 	     :icon (format "  %s\t" (all-the-icons-fileicon "verilog" :face 'all-the-icons-red))
 	     :extensions ("v" "vh" "sv"))
 	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-octicon "file-media" :v-adjust 0 :face face-spec))
-	     :extensions ("png" "jpg" "jpeg" "gif" "ico" "tif" "tiff" "svg" "bmp"
-			  "psd" "ai" "eps" "indd" "mov" "avi" "mp4" "webm" "mkv"
-			  "wav" "mp3" "ogg" "midi"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-octicon "book" :v-adjust 0 :face face-spec))
-	     :extensions ("lrf" "lrx" "cbr" "cbz" "cb7" "cbt" "cba" "chm" "djvu"
-			  "doc" "docx" "pdb" "pdb" "fb2" "xeb" "ceb" "inf" "azw"
-			  "azw3" "kf8" "kfx" "lit" "prc" "mobi" "exe" "or"
-			  "pkg" "opf" "txt" "pdb" "ps" "rtf" "pdg" "xml" "tr2"
-			  "tr3" "oxps" "xps"))
+	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.log"))
+	     :extensions ("log"))
 	    (treemacs-create-icon
 	     :icon (format "  %s\t" (all-the-icons-octicon "file-text" :v-adjust 0 :face face-spec))
-	     :extensions ("txt" "CONTRIBUTE" "LICENSE" "README" "CHANGELOG"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-octicon "file-binary" :v-adjust 0 :face face-spec))
-	     :extensions ("exe" "dll" "obj" "so" "o" "out"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-octicon "file-zip" :v-adjust 0 :face face-spec))
-	     :extensions ("zip" "7z" "tar" "gz" "rar" "tgz"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-octicon "file-text" :v-adjust 0 :face face-spec))
-	     :extensions (fallback)))
+	     :extensions ("txt" "CONTRIBUTE" "LICENSE" "README" "CHANGELOG")))
 	;; else, display a minimalistic Atom-esque theme
-	(treemacs-create-icon
-	 :icon (format " %s\t" (all-the-icons-octicon "repo" :v-adjust -0.1 :face face-spec))
-	 :extensions (root))
-	(treemacs-create-icon
-	 :icon (format "%s\t%s\t"
-		       (all-the-icons-octicon "chevron-down" :height 0.75 :v-adjust 0.1 :face face-spec)
-		       (all-the-icons-octicon "file-directory" :v-adjust 0 :face face-spec))
-	 :extensions (dir-open))
-	(treemacs-create-icon
-	 :icon (format "%s\t%s\t"
-		       (all-the-icons-octicon "chevron-right" :height 0.75 :v-adjust 0.1 :face face-spec)
-		       (all-the-icons-octicon "file-directory" :v-adjust 0 :face face-spec))
-	 :extensions (dir-closed))
 	(treemacs-create-icon
 	 :icon (format "%s\t%s\t"
 		       (all-the-icons-octicon "chevron-down" :height 0.75 :v-adjust 0.1 :face face-spec)
@@ -362,11 +352,6 @@ variable-pitch face."
 	 :icon (format "%s\t" (all-the-icons-octicon "info" :height 0.75 :v-adjust 0.1 :face face-spec))
 	 :extensions (info))
 	(treemacs-create-icon
-	 :icon (format "  %s\t" (all-the-icons-octicon "file-media" :v-adjust 0 :face face-spec))
-	 :extensions ("png" "jpg" "jpeg" "gif" "ico" "tif" "tiff" "svg" "bmp"
-		      "psd" "ai" "eps" "indd" "mov" "avi" "mp4" "webm" "mkv"
-		      "wav" "mp3" "ogg" "midi"))
-	(treemacs-create-icon
 	 :icon (format "  %s\t" (all-the-icons-octicon "file-code" :v-adjust 0 :face face-spec))
 	 :extensions ("yml" "yaml" "sh" "zsh" "fish" "c" "h" "cpp" "cxx" "hpp"
 		      "tpp" "cc" "hh" "hs" "lhs" "cabal" "py" "pyc" "rs" "el"
@@ -381,27 +366,14 @@ variable-pitch face."
 		      "gitconfig"))
 	(treemacs-create-icon
 	 :icon (format "  %s\t" (all-the-icons-octicon "book" :v-adjust 0 :face face-spec))
-	 :extensions ("lrf" "lrx" "cbr" "cbz" "cb7" "cbt" "cba" "chm" "djvu"
-		      "doc" "docx" "pdb" "pdb" "fb2" "xeb" "ceb" "inf" "azw"
-		      "azw3" "kf8" "kfx" "lit" "prc" "mobi" "exe" "or" "html"
-		      "pkg" "opf" "txt" "pdb" "ps" "rtf" "pdg" "xml" "tr2"
-		      "tr3" "oxps" "xps"))
+	 :extensions ("html"))
 	(treemacs-create-icon
 	 :icon (format "  %s\t" (all-the-icons-octicon "file-text" :v-adjust 0 :face face-spec))
 	 :extensions ("md" "markdown" "rst" "log" "org" "txt"
 		      "CONTRIBUTE" "LICENSE" "README" "CHANGELOG"))
 	(treemacs-create-icon
-	 :icon (format "  %s\t" (all-the-icons-octicon "file-binary" :v-adjust 0 :face face-spec))
-	 :extensions ("exe" "dll" "obj" "so" "o" "out"))
-	(treemacs-create-icon
 	 :icon (format "  %s\t" (all-the-icons-octicon "file-pdf" :v-adjust 0 :face face-spec))
-	 :extensions ("pdf"))
-	(treemacs-create-icon
-	 :icon (format "  %s\t" (all-the-icons-octicon "file-zip" :v-adjust 0 :face face-spec))
-	 :extensions ("zip" "7z" "tar" "gz" "rar" "tgz"))
-	(treemacs-create-icon
-	 :icon (format "  %s\t" (all-the-icons-octicon "file-text" :v-adjust 0 :face face-spec))
-	 :extensions (fallback)))))
+	 :extensions ("pdf")))))
 
   (treemacs-load-theme "doom"))
 

--- a/doom-themes-ext-treemacs.el
+++ b/doom-themes-ext-treemacs.el
@@ -103,19 +103,19 @@ variable-pitch face."
        :extensions (root))
       (treemacs-create-icon
        :icon (format "%s\t%s\t"
-		     (all-the-icons-octicon "chevron-down" :height 0.75 :v-adjust 0.1 :face face-spec)
-		     (all-the-icons-octicon "file-directory" :v-adjust 0 :face face-spec))
+                     (all-the-icons-octicon "chevron-down" :height 0.75 :v-adjust 0.1 :face face-spec)
+                     (all-the-icons-octicon "file-directory" :v-adjust 0 :face face-spec))
        :extensions (dir-open))
       (treemacs-create-icon
        :icon (format "%s\t%s\t"
-		     (all-the-icons-octicon "chevron-right" :height 0.75 :v-adjust 0.1 :face face-spec)
-		     (all-the-icons-octicon "file-directory" :v-adjust 0 :face face-spec))
+                     (all-the-icons-octicon "chevron-right" :height 0.75 :v-adjust 0.1 :face face-spec)
+                     (all-the-icons-octicon "file-directory" :v-adjust 0 :face face-spec))
        :extensions (dir-closed))
       (treemacs-create-icon
        :icon (format "  %s\t" (all-the-icons-octicon "file-media" :v-adjust 0 :face face-spec))
        :extensions ("png" "jpg" "jpeg" "gif" "ico" "tif" "tiff" "svg" "bmp"
-		    "psd" "ai" "eps" "indd" "mov" "avi" "mp4" "webm" "mkv"
-		    "wav" "mp3" "ogg" "midi"))
+                    "psd" "ai" "eps" "indd" "mov" "avi" "mp4" "webm" "mkv"
+                    "wav" "mp3" "ogg" "midi"))
       (treemacs-create-icon
        :icon (format "  %s\t" (all-the-icons-octicon "file-binary" :v-adjust 0 :face face-spec))
        :extensions ("exe" "dll" "obj" "so" "o" "out"))
@@ -125,255 +125,255 @@ variable-pitch face."
       (treemacs-create-icon
        :icon (format "  %s\t" (all-the-icons-octicon "book" :v-adjust 0 :face face-spec))
        :extensions ("lrf" "lrx" "cbr" "cbz" "cb7" "cbt" "cba" "chm" "djvu"
-		    "doc" "docx" "pdb" "pdb" "fb2" "xeb" "ceb" "inf" "azw"
-		    "azw3" "kf8" "kfx" "lit" "prc" "mobi" "exe" "or" "pkg"
-		    "opf" "txt" "pdb" "ps" "rtf" "pdg" "xml" "tr2" "tr3"
-		    "oxps" "xps"))
+                    "doc" "docx" "pdb" "pdb" "fb2" "xeb" "ceb" "inf" "azw"
+                    "azw3" "kf8" "kfx" "lit" "prc" "mobi" "exe" "or" "pkg"
+                    "opf" "txt" "pdb" "ps" "rtf" "pdg" "xml" "tr2" "tr3"
+                    "oxps" "xps"))
       (treemacs-create-icon
        :icon (format "  %s\t" (all-the-icons-octicon "file-text" :v-adjust 0 :face face-spec))
        :extensions (fallback))
       (if doom-themes-treemacs-color-icons
-	  ;; if `doom-themes-treemacs-color-icons' is non-nil, display a more colorful Treemacs theme.
-	  (progn
-	    (treemacs-create-icon
-	     :icon (format "%s\t%s\t"
-			   (all-the-icons-octicon "chevron-down" :height 0.75 :v-adjust 0.1 :face face-spec)
-			   (all-the-icons-faicon "cube"
-						 :v-adjust 0.1
-						 :face 'font-lock-function-name-face))
-	     :extensions (tag-open))
-	    (treemacs-create-icon
-	     :icon (format "%s\t%s\t"
-			   (all-the-icons-octicon "chevron-right" :height 0.75 :v-adjust 0.1 :face face-spec)
-			   (all-the-icons-faicon "cube"
-						 :v-adjust 0.1
-						 :face 'font-lock-function-name-face))
-	     :extensions (tag-closed))
-	    (treemacs-create-icon
-	     :icon (format "%s " (all-the-icons-faicon "tag"
-						       :height 0.9
-						       :face 'font-lock-variable-name-face))
-	     :extensions (tag-leaf))
-	    (treemacs-create-icon
-	     :icon (format "%s\t" (all-the-icons-octicon "flame" :v-adjust 0 :face 'all-the-icons-red))
-	     :extensions (error))
-	    (treemacs-create-icon
-	     :icon (format "%s\t" (all-the-icons-octicon "stop" :v-adjust 0 :face 'all-the-icons-yellow))
-	     :extensions (warning))
-	    (treemacs-create-icon
-	     :icon (format "%s\t" (all-the-icons-octicon "info" :height 0.75 :v-adjust 0.1 :face 'all-the-icons-green))
-	     :extensions (info))
-	    ;; Icons for filetypes
-	    (treemacs-create-icon
-	     :icon (format " %s " (all-the-icons-icon-for-file "foo.cs"))
-	     :extensions ("cs"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-icon-for-file "fo.css"))
-	     :extensions ("css"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.git"))
-	     :extensions ("gitignore" "git" "gitconfig" "gitmodules"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.html"))
-	     :extensions ("html" "htm"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.java"))
-	     :extensions ("java"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.py"))
-	     :extensions ("py"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.rs"))
-	     :extensions ("rs"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.hs"))
-	     :extensions ("hs"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.c"))
-	     :extensions ("c" "h"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.cpp"))
-	     :extensions ("cpp" "cxx" "hpp" "tpp" "cc" "hh"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.rb"))
-	     :extensions ("rb"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.scala"))
-	     :extensions ("scala"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.ex"))
-	     :extensions ("ex" "exs"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.erl"))
-	     :extensions ("erl" "hrl")) ;
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.clj"))
-	     :extensions ("clj" "cljs" "cljc"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-fileicon "cabal" :face face-spec))
-	     :extensions ("cabal"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.lisp"))
-	     :extensions ("lisp"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.go"))
-	     :extensions ("go"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.el"))
-	     :extensions ("el" "elc"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.jl"))
-	     :extensions ("jl"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-fileicon "kotlin" :face face-spec))
-	     :extensions ("kt" "kts"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.hy"))
-	     :extensions ("hy"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.js"))
-	     :extensions ("js"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.jsx"))
-	     :extensions ("jsx"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.ml"))
-	     :extensions ("ml" "mli"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.org"))
-	     :extensions ("org"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.php"))
-	     :extensions ("php"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.sh"))
-	     :extensions ("sh"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.zsh"))
-	     :extensions ("zsh"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.fish"))
-	     :extensions ("fish"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.ts"))
-	     :extensions ("ts"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-fileicon "nimrod" :face face-spec))
-	     :extensions ("nim" "nims"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.pl"))
-	     :extensions ("pl" "pm" "perl"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-fileicon "perl6" :face face-spec))
-	     :extensions ("pm6"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.r"))
-	     :extensions ("r"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.tex"))
-	     :extensions ("tex"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.rst"))
-	     :extensions ("rst"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.vue"))
-	     :extensions ("vue"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.md"))
-	     :extensions ("md" "markdown"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.pdf"))
-	     :extensions ("pdf"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.csv"))
-	     :extensions ("csv"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-octicon "database" :face face-spec))
-	     :extensions ("sql"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-material "style" :face face-spec))
-	     :extensions ("styles"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-fileicon "lua" :face face-spec))
-	     :extensions ("lua"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-fileicon "asciidoc" :face face-spec))
-	     :extensions ("adoc" "asciidoc"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.sbt"))
-	     :extensions ("sbt"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-fileicon "puppet" :face face-spec))
-	     :extensions ("pp"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-fileicon "jinja" :face face-spec))
-	     :extensions ("j2" "jinja2"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-fileicon "dockerfile" :face face-spec))
-	     :extensions ("dockerfile"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-fileicon "vagrant" :face face-spec))
-	     :extensions ("vagrantfile"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.rkt"))
-	     :extensions ("racket" "rkt" "rktl" "rktd" "scrbl" "scribble" "plt"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.reason"))
-	     :extensions ("re" "rei"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-fileicon "verilog" :face 'all-the-icons-red))
-	     :extensions ("v" "vh" "sv"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.log"))
-	     :extensions ("log"))
-	    (treemacs-create-icon
-	     :icon (format "  %s\t" (all-the-icons-octicon "file-text" :v-adjust 0 :face face-spec))
-	     :extensions ("txt" "CONTRIBUTE" "LICENSE" "README" "CHANGELOG")))
-	;; else, display a minimalistic Atom-esque theme
-	(treemacs-create-icon
-	 :icon (format "%s\t%s\t"
-		       (all-the-icons-octicon "chevron-down" :height 0.75 :v-adjust 0.1 :face face-spec)
-		       (all-the-icons-octicon "package" :v-adjust 0 :face face-spec)) :extensions (tag-open))
-	(treemacs-create-icon
-	 :icon (format "%s\t%s\t"
-		       (all-the-icons-octicon "chevron-right" :height 0.75 :v-adjust 0.1 :face face-spec)
-		       (all-the-icons-octicon "package" :v-adjust 0 :face face-spec))
-	 :extensions (tag-closed))
-	(treemacs-create-icon
-	 :icon (format "%s\t" (all-the-icons-octicon "tag" :height 0.9 :v-adjust 0 :face face-spec))
-	 :extensions (tag-leaf))
-	(treemacs-create-icon
-	 :icon (format "%s\t" (all-the-icons-octicon "flame" :v-adjust 0 :face face-spec))
-	 :extensions (error))
-	(treemacs-create-icon
-	 :icon (format "%s\t" (all-the-icons-octicon "stop" :v-adjust 0 :face face-spec))
-	 :extensions (warning))
-	(treemacs-create-icon
-	 :icon (format "%s\t" (all-the-icons-octicon "info" :height 0.75 :v-adjust 0.1 :face face-spec))
-	 :extensions (info))
-	(treemacs-create-icon
-	 :icon (format "  %s\t" (all-the-icons-octicon "file-code" :v-adjust 0 :face face-spec))
-	 :extensions ("yml" "yaml" "sh" "zsh" "fish" "c" "h" "cpp" "cxx" "hpp"
-		      "tpp" "cc" "hh" "hs" "lhs" "cabal" "py" "pyc" "rs" "el"
-		      "elc" "clj" "cljs" "cljc" "ts" "tsx" "vue" "css" "html"
-		      "htm" "dart" "java" "kt" "scala" "sbt" "go" "js" "jsx"
-		      "hy" "json" "jl" "ex" "exs" "eex" "ml" "mli" "pp" "dockerfile"
-		      "vagrantfile" "j2" "jinja2" "tex" "racket" "rkt" "rktl" "rktd"
-		      "scrbl" "scribble" "plt" "makefile" "elm" "xml" "xsl" "rb"
-		      "scss" "lua" "lisp" "scm" "sql" "toml" "nim" "pl" "pm" "perl"
-		      "vimrc" "tridactylrc" "vimperatorrc" "ideavimrc" "vrapperrc"
-		      "cask" "r" "re" "rei" "bashrc" "zshrc" "inputrc" "editorconfig"
-		      "gitconfig"))
-	(treemacs-create-icon
-	 :icon (format "  %s\t" (all-the-icons-octicon "book" :v-adjust 0 :face face-spec))
-	 :extensions ("html"))
-	(treemacs-create-icon
-	 :icon (format "  %s\t" (all-the-icons-octicon "file-text" :v-adjust 0 :face face-spec))
-	 :extensions ("md" "markdown" "rst" "log" "org" "txt"
-		      "CONTRIBUTE" "LICENSE" "README" "CHANGELOG"))
-	(treemacs-create-icon
-	 :icon (format "  %s\t" (all-the-icons-octicon "file-pdf" :v-adjust 0 :face face-spec))
-	 :extensions ("pdf")))))
+          ;; if `doom-themes-treemacs-color-icons' is non-nil, display a more colorful Treemacs theme.
+          (progn
+            (treemacs-create-icon
+             :icon (format "%s\t%s\t"
+                           (all-the-icons-octicon "chevron-down" :height 0.75 :v-adjust 0.1 :face face-spec)
+                           (all-the-icons-faicon "cube"
+                                                 :v-adjust 0.1
+                                                 :face 'font-lock-function-name-face))
+             :extensions (tag-open))
+            (treemacs-create-icon
+             :icon (format "%s\t%s\t"
+                           (all-the-icons-octicon "chevron-right" :height 0.75 :v-adjust 0.1 :face face-spec)
+                           (all-the-icons-faicon "cube"
+                                                 :v-adjust 0.1
+                                                 :face 'font-lock-function-name-face))
+             :extensions (tag-closed))
+            (treemacs-create-icon
+             :icon (format "%s " (all-the-icons-faicon "tag"
+                                                       :height 0.9
+                                                       :face 'font-lock-variable-name-face))
+             :extensions (tag-leaf))
+            (treemacs-create-icon
+             :icon (format "%s\t" (all-the-icons-octicon "flame" :v-adjust 0 :face 'all-the-icons-red))
+             :extensions (error))
+            (treemacs-create-icon
+             :icon (format "%s\t" (all-the-icons-octicon "stop" :v-adjust 0 :face 'all-the-icons-yellow))
+             :extensions (warning))
+            (treemacs-create-icon
+             :icon (format "%s\t" (all-the-icons-octicon "info" :height 0.75 :v-adjust 0.1 :face 'all-the-icons-green))
+             :extensions (info))
+            ;; Icons for filetypes
+            (treemacs-create-icon
+             :icon (format " %s " (all-the-icons-icon-for-file "foo.cs"))
+             :extensions ("cs"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-icon-for-file "fo.css"))
+             :extensions ("css"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.git"))
+             :extensions ("gitignore" "git" "gitconfig" "gitmodules"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.html"))
+             :extensions ("html" "htm"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.java"))
+             :extensions ("java"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.py"))
+             :extensions ("py"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.rs"))
+             :extensions ("rs"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.hs"))
+             :extensions ("hs"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.c"))
+             :extensions ("c" "h"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.cpp"))
+             :extensions ("cpp" "cxx" "hpp" "tpp" "cc" "hh"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.rb"))
+             :extensions ("rb"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.scala"))
+             :extensions ("scala"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.ex"))
+             :extensions ("ex" "exs"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.erl"))
+             :extensions ("erl" "hrl")) ;
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.clj"))
+             :extensions ("clj" "cljs" "cljc"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-fileicon "cabal" :face face-spec))
+             :extensions ("cabal"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.lisp"))
+             :extensions ("lisp"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.go"))
+             :extensions ("go"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.el"))
+             :extensions ("el" "elc"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.jl"))
+             :extensions ("jl"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-fileicon "kotlin" :face face-spec))
+             :extensions ("kt" "kts"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.hy"))
+             :extensions ("hy"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.js"))
+             :extensions ("js"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.jsx"))
+             :extensions ("jsx"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.ml"))
+             :extensions ("ml" "mli"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.org"))
+             :extensions ("org"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.php"))
+             :extensions ("php"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.sh"))
+             :extensions ("sh"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.zsh"))
+             :extensions ("zsh"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.fish"))
+             :extensions ("fish"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.ts"))
+             :extensions ("ts"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-fileicon "nimrod" :face face-spec))
+             :extensions ("nim" "nims"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.pl"))
+             :extensions ("pl" "pm" "perl"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-fileicon "perl6" :face face-spec))
+             :extensions ("pm6"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.r"))
+             :extensions ("r"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.tex"))
+             :extensions ("tex"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.rst"))
+             :extensions ("rst"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.vue"))
+             :extensions ("vue"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.md"))
+             :extensions ("md" "markdown"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.pdf"))
+             :extensions ("pdf"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.csv"))
+             :extensions ("csv"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-octicon "database" :face face-spec))
+             :extensions ("sql"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-material "style" :face face-spec))
+             :extensions ("styles"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-fileicon "lua" :face face-spec))
+             :extensions ("lua"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-fileicon "asciidoc" :face face-spec))
+             :extensions ("adoc" "asciidoc"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.sbt"))
+             :extensions ("sbt"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-fileicon "puppet" :face face-spec))
+             :extensions ("pp"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-fileicon "jinja" :face face-spec))
+             :extensions ("j2" "jinja2"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-fileicon "dockerfile" :face face-spec))
+             :extensions ("dockerfile"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-fileicon "vagrant" :face face-spec))
+             :extensions ("vagrantfile"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.rkt"))
+             :extensions ("racket" "rkt" "rktl" "rktd" "scrbl" "scribble" "plt"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.reason"))
+             :extensions ("re" "rei"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-fileicon "verilog" :face 'all-the-icons-red))
+             :extensions ("v" "vh" "sv"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-icon-for-file "foo.log"))
+             :extensions ("log"))
+            (treemacs-create-icon
+             :icon (format "  %s\t" (all-the-icons-octicon "file-text" :v-adjust 0 :face face-spec))
+             :extensions ("txt" "CONTRIBUTE" "LICENSE" "README" "CHANGELOG")))
+        ;; else, display a minimalistic Atom-esque theme
+        (treemacs-create-icon
+         :icon (format "%s\t%s\t"
+                       (all-the-icons-octicon "chevron-down" :height 0.75 :v-adjust 0.1 :face face-spec)
+                       (all-the-icons-octicon "package" :v-adjust 0 :face face-spec)) :extensions (tag-open))
+        (treemacs-create-icon
+         :icon (format "%s\t%s\t"
+                       (all-the-icons-octicon "chevron-right" :height 0.75 :v-adjust 0.1 :face face-spec)
+                       (all-the-icons-octicon "package" :v-adjust 0 :face face-spec))
+         :extensions (tag-closed))
+        (treemacs-create-icon
+         :icon (format "%s\t" (all-the-icons-octicon "tag" :height 0.9 :v-adjust 0 :face face-spec))
+         :extensions (tag-leaf))
+        (treemacs-create-icon
+         :icon (format "%s\t" (all-the-icons-octicon "flame" :v-adjust 0 :face face-spec))
+         :extensions (error))
+        (treemacs-create-icon
+         :icon (format "%s\t" (all-the-icons-octicon "stop" :v-adjust 0 :face face-spec))
+         :extensions (warning))
+        (treemacs-create-icon
+         :icon (format "%s\t" (all-the-icons-octicon "info" :height 0.75 :v-adjust 0.1 :face face-spec))
+         :extensions (info))
+        (treemacs-create-icon
+         :icon (format "  %s\t" (all-the-icons-octicon "file-code" :v-adjust 0 :face face-spec))
+         :extensions ("yml" "yaml" "sh" "zsh" "fish" "c" "h" "cpp" "cxx" "hpp"
+                      "tpp" "cc" "hh" "hs" "lhs" "cabal" "py" "pyc" "rs" "el"
+                      "elc" "clj" "cljs" "cljc" "ts" "tsx" "vue" "css" "html"
+                      "htm" "dart" "java" "kt" "scala" "sbt" "go" "js" "jsx"
+                      "hy" "json" "jl" "ex" "exs" "eex" "ml" "mli" "pp" "dockerfile"
+                      "vagrantfile" "j2" "jinja2" "tex" "racket" "rkt" "rktl" "rktd"
+                      "scrbl" "scribble" "plt" "makefile" "elm" "xml" "xsl" "rb"
+                      "scss" "lua" "lisp" "scm" "sql" "toml" "nim" "pl" "pm" "perl"
+                      "vimrc" "tridactylrc" "vimperatorrc" "ideavimrc" "vrapperrc"
+                      "cask" "r" "re" "rei" "bashrc" "zshrc" "inputrc" "editorconfig"
+                      "gitconfig"))
+        (treemacs-create-icon
+         :icon (format "  %s\t" (all-the-icons-octicon "book" :v-adjust 0 :face face-spec))
+         :extensions ("html"))
+        (treemacs-create-icon
+         :icon (format "  %s\t" (all-the-icons-octicon "file-text" :v-adjust 0 :face face-spec))
+         :extensions ("md" "markdown" "rst" "log" "org" "txt"
+                      "CONTRIBUTE" "LICENSE" "README" "CHANGELOG"))
+        (treemacs-create-icon
+         :icon (format "  %s\t" (all-the-icons-octicon "file-pdf" :v-adjust 0 :face face-spec))
+         :extensions ("pdf")))))
 
   (treemacs-load-theme "doom"))
 


### PR DESCRIPTION
Given it's a little heavy change, I decided it was better to assign a reviewer. This change adds a `doom-themes-treemacs-color-icons` flag that when true, displays a more colorful Treemacs theme than the original, minimal atom inspired implementation by Henrik.