### PR TITLE
Add: common faces for man and woman

### DIFF
--- a/doom-themes-base.el
+++ b/doom-themes-base.el
@@ -1138,6 +1138,10 @@
     ;; makefile-*-mode
     (makefile-targets :foreground blue)
 
+    ;; man-mode
+    (Man-overstrike :inherit 'bold :foreground orange)
+    (Man-underline :inherit 'underline :foreground green)
+
     ;; markdown-mode
     (markdown-header-face           :inherit 'bold :foreground highlight)
     (markdown-header-delimiter-face :inherit 'markdown-header-face)
@@ -1312,7 +1316,11 @@
     (web-mode-html-attr-name-face    :foreground type)
     (web-mode-html-entity-face       :foreground cyan :inherit 'italic)
     (web-mode-block-control-face     :foreground orange)
-    (web-mode-html-tag-bracket-face  :foreground operators))
+    (web-mode-html-tag-bracket-face  :foreground operators)
+
+    ;; woman
+    (woman-bold :inherit 'Man-overstrike)
+    (woman-italic :inherit 'Man-underline))
   "TODO")
 
 (defvar doom-themes-base-vars


### PR DESCRIPTION
Related with https://github.com/hlissner/emacs-doom-themes/pull/325.

Note that themes `palenight` and `moonlight` already set their own faces for `man`.
