### PR TITLE
Use face-remap in visual bell

### DIFF
--- a/doom-themes-ext-visual-bell.el
+++ b/doom-themes-ext-visual-bell.el
@@ -1,30 +1,22 @@
 ;;; doom-themes-ext-visual-bell.el --- flash mode-line on error -*- lexical-binding: t; -*-
 
+(require 'face-remap)
+
 (defface doom-visual-bell '((t (:inherit error :inverse-video t)))
   "Face to use for the mode-line when `doom-themes-visual-bell-config' is used."
   :group 'doom-themes)
 
-(defvar doom-themes--bell-p nil)
 ;;;###autoload
 (defun doom-themes-visual-bell-fn ()
   "Blink the mode-line red briefly. Set `ring-bell-function' to this to use it."
-  (unless doom-themes--bell-p
-    (let ((old-remap (copy-alist face-remapping-alist)))
-      (setq doom-themes--bell-p t)
-      (setq face-remapping-alist
-            (append (delete (assq 'mode-line face-remapping-alist)
-                            face-remapping-alist)
-                    '((mode-line doom-visual-bell))))
-      (force-mode-line-update)
-      (run-with-timer 0.15 nil
-                      (lambda (remap buf)
-                        (with-current-buffer buf
-                          (when (assq 'mode-line face-remapping-alist)
-                            (setq face-remapping-alist remap
-                                  doom-themes--bell-p nil))
-                          (force-mode-line-update)))
-                      old-remap
-                      (current-buffer)))))
+  (let ((doom-themes--bell-cookie (face-remap-add-relative 'mode-line 'doom-visual-bell)))
+    (force-mode-line-update)
+    (run-with-timer 0.15 nil
+                    (lambda (cookie buf)
+                      (with-current-buffer buf
+                        (face-remap-remove-relative cookie)))
+                    doom-themes--bell-cookie
+                    (current-buffer))))
 
 ;;;###autoload
 (defun doom-themes-visual-bell-config ()

--- a/doom-themes-ext-visual-bell.el
+++ b/doom-themes-ext-visual-bell.el
@@ -14,7 +14,8 @@
     (run-with-timer 0.15 nil
                     (lambda (cookie buf)
                       (with-current-buffer buf
-                        (face-remap-remove-relative cookie)))
+                        (face-remap-remove-relative cookie)
+                        (force-mode-line-update)))
                     doom-themes--bell-cookie
                     (current-buffer))))
 


### PR DESCRIPTION
Use `face-remap.el` rather than modifying `face-remapping-alist` directly.

Long explanation:

I was having modelines stuck in inverse video, and developed a hunch that it was something between flycheck-color-mode-line and doom-theme. I found some files that would make it happen consistently and here is what appears to have happened:

1. I open the file and something triggers the bell (in this case `company-clang` complaining it couldn't find the executable, but that's not important).
2. `doom-themes-visual-bell-fn` adds a face remapping and stores the old remapping list.
3. Flycheck finishes, sets the state and flycheck-color-mode-line adds a remapping using `face-remap-add-relative`.
4. `face-remap-add-relative` makes `face-remapping-alist` buffer local and modifies it.
5. The timer function `doom-themes-visual-bell-fn` started gets called, and resets the now buffer local `face-remapping-alist`, but the global value still contain `doom-visual-bell` making the modeline for all new buffers permanently "bell-y".

Ensuring that `face-remapping-alist` is buffer local before a bell is triggered half fixes the problem: It doesn't get stuck, but doom-themes erase the remapping flycheck-color-mode-line sets.

This PR makes doom-themes use face-remap.el too, which stated purpose is "maintaining the `face-remapping-alist` in a cooperative way". The only side-effect is that bells will make `face-remapping-alist`buffer-local which isn't strictly necessary for doom-themes (but certainly is for flycheck-color-mode-line), but avoiding that would seriously complicate things.