### PR TITLE
Fix customization type of padded-modeline.

### DIFF
--- a/doom-themes.el
+++ b/doom-themes.el
@@ -84,7 +84,7 @@
 (defcustom doom-themes-padded-modeline nil
   "Default value for padded-modeline setting for themes that support it."
   :group 'doom-themes
-  :type '(or integer boolean))
+  :type '(choice integer boolean))
 
 ;;
 (defcustom doom-themes-enable-bold t

--- a/themes/doom-Iosvkem-theme.el
+++ b/themes/doom-Iosvkem-theme.el
@@ -26,7 +26,7 @@ legibility."
   "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
 determine the exact padding."
   :group 'doom-Iosvkem-theme
-  :type '(or integer boolean))
+  :type '(choice integer boolean))
 
 ;;
 (def-doom-theme doom-Iosvkem

--- a/themes/doom-challenger-deep-theme.el
+++ b/themes/doom-challenger-deep-theme.el
@@ -26,7 +26,7 @@ legibility."
   "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
 determine the exact padding."
   :group 'doom-challenger-deep-theme
-  :type '(or integer boolean))
+  :type '(choice integer boolean))
 
 ;;
 (def-doom-theme doom-challenger-deep

--- a/themes/doom-city-lights-theme.el
+++ b/themes/doom-city-lights-theme.el
@@ -26,7 +26,7 @@ legibility."
   "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
 determine the exact padding."
   :group 'doom-city-lights-theme
-  :type '(or integer boolean))
+  :type '(choice integer boolean))
 
 ;;
 (def-doom-theme doom-city-lights

--- a/themes/doom-dracula-theme.el
+++ b/themes/doom-dracula-theme.el
@@ -32,7 +32,7 @@ legibility."
   "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
 determine the exact padding."
   :group 'doom-dracula-theme
-  :type '(or integer boolean))
+  :type '(choice integer boolean))
 
 ;;
 (def-doom-theme doom-dracula

--- a/themes/doom-fairy-floss-theme.el
+++ b/themes/doom-fairy-floss-theme.el
@@ -26,7 +26,7 @@ legibility."
   "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
 determine the exact padding."
   :group 'doom-fairy-floss-theme
-  :type '(or integer boolean))
+  :type '(choice integer boolean))
 
 ;;
 (def-doom-theme doom-fairy-floss

--- a/themes/doom-gruvbox-theme.el
+++ b/themes/doom-gruvbox-theme.el
@@ -18,7 +18,7 @@
   "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
 determine the exact padding."
   :group 'doom-gruvbox-theme
-  :type '(or integer boolean))
+  :type '(choice integer boolean))
 
 ;;
 (def-doom-theme doom-gruvbox

--- a/themes/doom-molokai-theme.el
+++ b/themes/doom-molokai-theme.el
@@ -26,7 +26,7 @@ legibility."
   "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
 determine the exact padding."
   :group 'doom-molokai-theme
-  :type '(or integer boolean))
+  :type '(choice integer boolean))
 
 ;;
 (def-doom-theme doom-molokai

--- a/themes/doom-moonlight-theme.el
+++ b/themes/doom-moonlight-theme.el
@@ -10,7 +10,7 @@
   "If non-nil, adds a 4px padding to the mode-line.
 Can be an integer to determine the exact padding."
   :group 'doom-moonlight-theme
-  :type '(or integer boolean))
+  :type '(choice integer boolean))
 
 ;;
 (def-doom-theme doom-moonlight

--- a/themes/doom-nord-light-theme.el
+++ b/themes/doom-nord-light-theme.el
@@ -26,7 +26,7 @@ legibility."
   "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
 determine the exact padding."
   :group 'doom-nord-light-theme
-  :type '(or integer boolean))
+  :type '(choice integer boolean))
 
 (defcustom doom-nord-light-region-highlight t
   "Determines the selection highlight style. Can be 'frost, 'snowstorm or t

--- a/themes/doom-nord-theme.el
+++ b/themes/doom-nord-theme.el
@@ -26,7 +26,7 @@ legibility."
   "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
 determine the exact padding."
   :group 'doom-nord-theme
-  :type '(or integer boolean))
+  :type '(choice integer boolean))
 
 (eval-and-compile
   (defcustom doom-nord-region-highlight t

--- a/themes/doom-nova-theme.el
+++ b/themes/doom-nova-theme.el
@@ -9,7 +9,7 @@
   "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
 determine the exact padding."
   :group 'doom-nova-theme
-  :type '(or integer boolean))
+  :type '(choice integer boolean))
 
 (def-doom-theme doom-nova
   "A light theme inspired by Trevord Miller's Nova. See

--- a/themes/doom-one-light-theme.el
+++ b/themes/doom-one-light-theme.el
@@ -26,7 +26,7 @@ legibility."
   "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
 determine the exact padding."
   :group 'doom-one-light-theme
-  :type '(or integer boolean))
+  :type '(choice integer boolean))
 
 ;;
 (def-doom-theme doom-one-light

--- a/themes/doom-one-theme.el
+++ b/themes/doom-one-theme.el
@@ -26,7 +26,7 @@ legibility."
   "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
 determine the exact padding."
   :group 'doom-one-theme
-  :type '(or integer boolean))
+  :type '(choice integer boolean))
 
 ;;
 (def-doom-theme doom-one

--- a/themes/doom-opera-light-theme.el
+++ b/themes/doom-opera-light-theme.el
@@ -26,7 +26,7 @@ legibility."
   "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
 determine the exact padding."
   :group 'doom-opera-light-theme
-  :type '(or integer boolean))
+  :type '(choice integer boolean))
 
 (defcustom doom-opera-light-region-highlight t
   "Determines the selection highlight style. Can be 'frost, 'snowstorm or t

--- a/themes/doom-opera-theme.el
+++ b/themes/doom-opera-theme.el
@@ -26,7 +26,7 @@ legibility."
   "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
 determine the exact padding."
   :group 'doom-opera-theme
-  :type '(or integer boolean))
+  :type '(choice integer boolean))
 
 (defcustom doom-opera-region-highlight t
   "Determines the selection highlight style. Can be 'frost, 'snowstorm or t

--- a/themes/doom-outrun-electric-theme.el
+++ b/themes/doom-outrun-electric-theme.el
@@ -26,7 +26,7 @@ legibility."
   "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
 determine the exact padding."
   :group 'doom-outrun-electric-theme
-  :type '(or integer boolean))
+  :type '(choice integer boolean))
 
 ;;
 (def-doom-theme doom-outrun-electric

--- a/themes/doom-palenight-theme.el
+++ b/themes/doom-palenight-theme.el
@@ -10,7 +10,7 @@
   "If non-nil, adds a 4px padding to the mode-line.
 Can be an integer to determine the exact padding."
   :group 'doom-palenight-theme
-  :type '(or integer boolean))
+  :type '(choice integer boolean))
 
 ;;
 (def-doom-theme doom-palenight

--- a/themes/doom-peacock-theme.el
+++ b/themes/doom-peacock-theme.el
@@ -25,7 +25,7 @@ legibility."
   "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
 determine the exact padding."
   :group 'doom-peacock-theme
-  :type '(or integer boolean))
+  :type '(choice integer boolean))
 
 ;;
 (def-doom-theme doom-peacock

--- a/themes/doom-solarized-dark-theme.el
+++ b/themes/doom-solarized-dark-theme.el
@@ -26,7 +26,7 @@ legibility."
   "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
 determine the exact padding."
   :group 'doom-solarized-dark-theme
-  :type '(or integer boolean))
+  :type '(choice integer boolean))
 
 ;;
 (def-doom-theme doom-solarized-dark

--- a/themes/doom-solarized-light-theme.el
+++ b/themes/doom-solarized-light-theme.el
@@ -26,7 +26,7 @@ legibility."
   "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
 determine the exact padding."
   :group 'doom-solarized-light-theme
-  :type '(or integer boolean))
+  :type '(choice integer boolean))
 
 ;;
 (def-doom-theme doom-solarized-light

--- a/themes/doom-sourcerer-theme.el
+++ b/themes/doom-sourcerer-theme.el
@@ -27,7 +27,7 @@ Enhancing their legibility."
   "If non-nil, adds a 4px padding to the mode-line.
 Can be an integer to determine the exact padding."
   :group 'doom-sourcerer-theme
-  :type '(or integer boolean))
+  :type '(choice integer boolean))
 
 
 ;;

--- a/themes/doom-spacegrey-theme.el
+++ b/themes/doom-spacegrey-theme.el
@@ -25,7 +25,7 @@ legibility."
   "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
 determine the exact padding."
   :group 'doom-spacegrey-theme
-  :type '(or integer boolean))
+  :type '(choice integer boolean))
 
 ;;
 (def-doom-theme doom-spacegrey

--- a/themes/doom-tomorrow-day-theme.el
+++ b/themes/doom-tomorrow-day-theme.el
@@ -14,7 +14,7 @@
   "If non-nil, adds a 4px padding to the mode-line.
 Can be an integer to determine the exact padding."
   :group 'doom-tomorrow-day-theme
-  :type '(or integer boolean))
+  :type '(choice integer boolean))
 
 (def-doom-theme doom-tomorrow-day
   "A light theme based off of Chris Kempson's Tomorrow Dark."

--- a/themes/doom-tomorrow-night-theme.el
+++ b/themes/doom-tomorrow-night-theme.el
@@ -9,7 +9,7 @@
   "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
 determine the exact padding."
   :group 'doom-tomorrow-night-theme
-  :type '(or integer boolean))
+  :type '(choice integer boolean))
 
 (def-doom-theme doom-tomorrow-night
   "A theme based off of Chris Kempson's Tomorrow Dark."

--- a/themes/doom-vibrant-theme.el
+++ b/themes/doom-vibrant-theme.el
@@ -26,7 +26,7 @@ legibility."
   "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
 determine the exact padding."
   :group 'doom-vibrant-theme
-  :type '(or integer boolean))
+  :type '(choice integer boolean))
 
 
 ;;

--- a/themes/doom-wilmersdorf-theme.el
+++ b/themes/doom-wilmersdorf-theme.el
@@ -10,7 +10,7 @@
   "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
 determine the exact padding."
   :group 'doom-wilmersdorf-theme
-  :type '(or integer boolean))
+  :type '(choice integer boolean))
 
 ;;
 (def-doom-theme doom-wilmersdorf


### PR DESCRIPTION
About `doom-themes-padded-modeline` and other `padded-modeline` suffixed customizable variables, I think `:type '(or integer boolean)` should be `:type '(choice integer boolean)`.

Elisp manual: https://www.gnu.org/software/emacs/manual/html_node/elisp/Composite-Types.html#Composite-Types