### PR TITLE
Mod: magit hunk heading face for city-lights

### DIFF
--- a/themes/doom-city-lights-theme.el
+++ b/themes/doom-city-lights-theme.el
@@ -121,9 +121,6 @@ determine the exact padding."
 
    (doom-modeline-bar :background (if -modeline-bright modeline-bg highlight))
 
-   (magit-diff-hunk-heading-highlight :foreground fg :background base4 :weight 'bold)
-   (magit-diff-hunk-heading :foreground fg-alt :background base3 :weight 'normal)
-
    (mode-line
     :background modeline-bg :foreground modeline-fg
     :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg)))
@@ -147,6 +144,10 @@ determine the exact padding."
    (css-proprietary-property :foreground orange)
    (css-property             :foreground green)
    (css-selector             :foreground blue)
+
+   ;; magit-mode
+   (magit-diff-hunk-heading-highlight :foreground fg :background base4 :weight 'bold)
+   (magit-diff-hunk-heading :foreground fg-alt :background base3 :weight 'normal)
 
    ;; markdown-mode
    (markdown-markup-face :foreground base5)

--- a/themes/doom-city-lights-theme.el
+++ b/themes/doom-city-lights-theme.el
@@ -121,6 +121,9 @@ determine the exact padding."
 
    (doom-modeline-bar :background (if -modeline-bright modeline-bg highlight))
 
+   (magit-diff-hunk-heading-highlight :foreground fg :background base4 :weight 'bold)
+   (magit-diff-hunk-heading :foreground fg-alt :background base3 :weight 'normal)
+
    (mode-line
     :background modeline-bg :foreground modeline-fg
     :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg)))


### PR DESCRIPTION
Using city-lights for a while now and there is a face that bothers me which is the magit hunk heading. I've changed the face to use less intrusive colors, and it works better for me. 

What are your thoughts about this change? Here is a snapshot from the Magit log for illustration of how it looks, both highlight and normal states:

current:
<img width="675" alt="Screen Shot 2019-10-01 at 5 53 38 PM" src="https://user-images.githubusercontent.com/33835/65979481-a14d1200-e475-11e9-9d2e-1b0772312888.png">


modified:
<img width="674" alt="Screen Shot 2019-10-01 at 5 51 19 PM" src="https://user-images.githubusercontent.com/33835/65979216-34d21300-e475-11e9-9984-997775c87bc7.png">
