### PR TITLE
Gruvbox: Remove background from org ellipses 

### DIFF
--- a/themes/doom-gruvbox-theme.el
+++ b/themes/doom-gruvbox-theme.el
@@ -243,7 +243,7 @@ determine the exact padding."
    (org-level-4 :inherit 'org-level-3)
    (org-level-5 :inherit 'org-level-3)
    (org-level-6 :inherit 'org-level-3)
-   (org-ellipsis :underline nil :background base2 :foreground orange)
+   (org-ellipsis :underline nil :background bg-alt :foreground orange)
    (org-tag :foreground yellow :bold nil)
    (org-quote :inherit 'italic :foreground base7 :background org-quote)
    (org-todo :foreground yellow :bold 'inherit)

--- a/themes/doom-gruvbox-theme.el
+++ b/themes/doom-gruvbox-theme.el
@@ -243,7 +243,7 @@ determine the exact padding."
    (org-level-4 :inherit 'org-level-3)
    (org-level-5 :inherit 'org-level-3)
    (org-level-6 :inherit 'org-level-3)
-   (org-ellipsis :underline nil :background bg-alt :foreground orange)
+   (org-ellipsis :underline nil :foreground orange)
    (org-tag :foreground yellow :bold nil)
    (org-quote :inherit 'italic :foreground base7 :background org-quote)
    (org-todo :foreground yellow :bold 'inherit)


### PR DESCRIPTION
**Before**

<img width="184" alt="Screenshot 2019-10-08 14 21 04" src="https://user-images.githubusercontent.com/12987958/66422240-554f1f80-e9d7-11e9-85e3-060e0822f7a5.png">


**After**
<img width="190" alt="Screenshot 2019-10-08 14 21 18" src="https://user-images.githubusercontent.com/12987958/66422201-436d7c80-e9d7-11e9-8369-2819b4d6cb54.png">
