### PR TITLE
add red background on gruvbox: ediff-current

### DIFF
--- a/themes/doom-gruvbox-theme.el
+++ b/themes/doom-gruvbox-theme.el
@@ -214,7 +214,8 @@ determine the exact padding."
    (button :foreground green :underline t :bold t)
 
    ;; ediff
-   (ediff-fine-diff-A :background (doom-blend red bg 0.3) :weight 'bold)
+   (ediff-fine-diff-A    :background (doom-blend red bg 0.3) :weight 'bold)
+   (ediff-current-diff-A :background (doom-blend red bg 0.1))
 
    ;; flycheck
    (flycheck-error   :underline `(:style wave :color ,red)    :background base3)


### PR DESCRIPTION
before:
<img width="635" alt="Screenshot 2019-11-14 at 11 04 47" src="https://user-images.githubusercontent.com/95058/68842618-4db62100-06cf-11ea-8ec2-bd3a8f21cf61.png">
after:
<img width="625" alt="Screenshot 2019-11-14 at 11 05 19" src="https://user-images.githubusercontent.com/95058/68842638-57d81f80-06cf-11ea-8657-b828d12cc595.png">
