### PR TITLE
gruvbox magit main view colors

### DIFF
--- a/themes/doom-gruvbox-theme.el
+++ b/themes/doom-gruvbox-theme.el
@@ -224,6 +224,25 @@ determine the exact padding."
    ;; helm
    (helm-swoop-target-line-face :foreground magenta :inverse-video t)
 
+    ;; magit
+   (magit-section-heading             :foreground yellow :weight 'bold)
+   (magit-section-heading-selection   :foreground dark-green)
+   (magit-filename                    :foreground fg)
+   (magit-branch-local                :foreground blue)
+   (magit-branch-current              :underline blue :inherit 'magit-branch-local)
+   (magit-branch-remote               :foreground green)
+   (magit-diff-hunk-heading           :background base3 :foreground fg-alt)
+   (magit-diff-hunk-heading-highlight :background accent :foreground fg)
+   (magit-diff-context                :foreground bg-alt :foreground fg-alt)
+   (magit-diff-context-highlight      :background bg-alt :foreground fg)
+   (magit-diff-added                  :foreground green)
+   (magit-diff-added-highlight        :foreground green :inherit 'magit-diff-context-highlight)
+   (magit-diff-removed                :foreground red)
+   (magit-diff-removed-highlight      :foreground red :inherit 'magit-diff-context-highlight)
+   (magit-hash                        :foreground cyan)
+   (magit-log-author                  :foreground red)
+   (magit-log-date                    :foreground dark-blue)
+ 
    ;;;;;;;; Major mode faces ;;;;;;;;
    ;; css-mode / scss-mode
    (css-proprietary-property :foreground keywords)

--- a/themes/doom-gruvbox-theme.el
+++ b/themes/doom-gruvbox-theme.el
@@ -224,24 +224,13 @@ determine the exact padding."
    ;; helm
    (helm-swoop-target-line-face :foreground magenta :inverse-video t)
 
-    ;; magit
+   ;; magit
    (magit-section-heading             :foreground yellow :weight 'bold)
-   (magit-section-heading-selection   :foreground dark-green)
-   (magit-filename                    :foreground fg)
-   (magit-branch-local                :foreground blue)
-   (magit-branch-current              :underline blue :inherit 'magit-branch-local)
-   (magit-branch-remote               :foreground green)
+   (magit-branch-current              :underline cyan :inherit 'magit-branch-local)
    (magit-diff-hunk-heading           :background base3 :foreground fg-alt)
    (magit-diff-hunk-heading-highlight :background accent :foreground fg)
    (magit-diff-context                :foreground bg-alt :foreground fg-alt)
-   (magit-diff-context-highlight      :background bg-alt :foreground fg)
-   (magit-diff-added                  :foreground green)
-   (magit-diff-added-highlight        :foreground green :inherit 'magit-diff-context-highlight)
-   (magit-diff-removed                :foreground red)
-   (magit-diff-removed-highlight      :foreground red :inherit 'magit-diff-context-highlight)
-   (magit-hash                        :foreground cyan)
-   (magit-log-author                  :foreground red)
-   (magit-log-date                    :foreground dark-blue)
+
  
    ;;;;;;;; Major mode faces ;;;;;;;;
    ;; css-mode / scss-mode


### PR DESCRIPTION
covers magit primary display scheme.
btw, how do I align multiple columns by `:`?

before:
![Screenshot 2019-11-15 at 14 31 51](https://user-images.githubusercontent.com/95058/68943808-dfe42500-07b4-11ea-95be-ec87534067ba.png)

after:
![Screenshot 2019-11-15 at 14 31 17](https://user-images.githubusercontent.com/95058/68943817-e5da0600-07b4-11ea-81e9-64f042b8a34e.png)

