### PR TITLE
add material theme

### DIFF
--- a/themes/doom-material-theme.el
+++ b/themes/doom-material-theme.el
@@ -1,0 +1,153 @@
+;;; doom-material-theme.el --- inspired by Material Theme by equinusocio
+(require 'doom-themes)
+
+;;
+(defgroup doom-material-theme nil
+  "Options for doom-themes"
+  :group 'doom-themes)
+
+(defcustom doom-material-padded-modeline doom-themes-padded-modeline
+  "If non-nil, adds a 4px padding to the mode-line.
+Can be an integer to determine the exact padding."
+  :group 'doom-material-theme
+  :type '(choice integer boolean))
+
+;;
+(def-doom-theme doom-material
+  "A dark theme inspired by Material Theme by equinusocio"
+
+  ;; name        default   256       16
+  ((bg         '("#1C262B" nil       nil))
+   (bg-alt     '("#263238" nil       nil))
+   (base0      '("#171F24" "black"   "black"))
+   (base1      '("#1C262B" "#262626" "brightblack"))
+   (base2      '("#222D32" "#303030" "brightblack"))
+   (base3      '("#171F24" "#3a3a3a" "brightblack"))
+   (base4      '("#314048" "#444444" "brightblack"))
+   (base5      '("#37474F" "#585858" "brightblack"))
+   (base6      '("#556369" "#626262" "brightblack"))
+   (base7      '("#737E84" "#767676" "brightblack"))
+   (base8      '("#9BA3A7" "#a8a8a8" "white"))
+   (fg         '("#EEFFFF" "#e4e4e4" "brightwhite"))
+   (fg-alt     '("#BFC7D5" "#bcbcbc" "white"))
+
+   (grey base5)
+
+   (red         '("#ff5370" "#ff0000" "red"))
+   (orange      '("#f78c6c" "#ff5f00" "brightred"))
+   (green       '("#c3e88d" "#afff00" "green"))
+   (teal        '("#44b9b1" "#00d7af" "brightgreen"))
+   (yellow      '("#ffcb6b" "#ffd700" "brightyellow"))
+   (blue        '("#82aaff" "#5fafff" "brightblue"))
+   (dark-blue   '("#7986E7" "#d7ffff" "blue"))
+   (magenta     '("#c792ea" "#d787d7" "brightmagenta"))
+   (violet      '("#bb80b3" "#d787af" "magenta"))
+   (cyan        '("#89DDFF" "#5fd7ff" "brightcyan"))
+   (dark-cyan   '("#80cbc4" "#00d7af" "cyan"))
+
+   ;; face categories -- required for all themes
+   (highlight      magenta)
+   (vertical-bar   base2)
+   (selection      base4)
+   (builtin        blue)
+   (comments       base6)
+   (doc-comments   base6)
+   (constants      orange)
+   (functions      blue)
+   (keywords       cyan)
+   (methods        blue)
+   (operators      cyan)
+   (type           magenta)
+   (strings        green)
+   (variables      yellow)
+   (numbers        orange)
+   (region         base3)
+   (error          red)
+   (warning        yellow)
+   (success        green)
+   (vc-modified    blue)
+   (vc-added       green)
+   (vc-deleted     red)
+
+   ;; custom categories
+   (modeline-bg     base2)
+   (modeline-bg-alt (doom-darken bg 0.01))
+   (modeline-fg     base8)
+   (modeline-fg-alt comments)
+
+   (-modeline-pad
+    (when doom-material-padded-modeline
+      (if (integerp doom-material-padded-modeline) doom-material-padded-modeline 4))))
+
+  ;; --- base faces ------------------------
+  (((lazy-highlight &override) :background base4 :foreground fg :distant-foreground fg :bold bold)
+   (doom-modeline-buffer-path       :foreground green :weight 'bold)
+   (doom-modeline-buffer-major-mode :inherit 'doom-modeline-buffer-path)
+
+   (mode-line
+    :background modeline-bg :foreground modeline-fg
+    :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg)))
+
+   (mode-line-inactive
+    :background modeline-bg-alt :foreground modeline-fg-alt
+    :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg-alt)))
+
+   (solaire-mode-line-face
+    :background modeline-bg :foreground modeline-fg
+    :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg)))
+   (solaire-mode-line-inactive-face
+    :background modeline-bg-alt :foreground modeline-fg-alt
+    :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg-alt)))
+
+   (fringe :background base2)
+
+   ;; --- major-mode faces ------------------------
+   ;; man-mode
+   (Man-overstrike :inherit 'bold :foreground magenta)
+   (Man-underline :inherit 'underline :foreground blue)
+
+   ;; org-mode
+   ((org-block &override) :background base2)
+   ((org-block-background &override) :background base2)
+   ((org-block-begin-line &override) :background base2)
+
+   ;; --- plugin faces -------------------
+   ;; css-mode / scss-mode
+   (css-proprietary-property :foreground orange)
+   (css-property             :foreground green)
+   (css-selector             :foreground blue)
+
+   ;; dired-k
+   (dired-k-commited :foreground base4)
+   (dired-k-modified :foreground vc-modified)
+   (dired-k-ignored :foreground cyan)
+   (dired-k-added    :foreground vc-added)
+
+
+   ;; js2-mode
+   (js2-jsdoc-tag              :foreground magenta)
+   (js2-object-property        :foreground yellow)
+   (js2-object-property-access :foreground cyan)
+   (js2-function-param         :foreground violet)
+   (js2-jsdoc-type             :foreground base8)
+   (js2-jsdoc-value            :foreground cyan)
+
+   ;; rainbow-delimiters
+   (rainbow-delimiters-depth-1-face :foreground magenta)
+   (rainbow-delimiters-depth-2-face :foreground orange)
+   (rainbow-delimiters-depth-3-face :foreground green)
+   (rainbow-delimiters-depth-4-face :foreground cyan)
+   (rainbow-delimiters-depth-5-face :foreground violet)
+   (rainbow-delimiters-depth-6-face :foreground yellow)
+   (rainbow-delimiters-depth-7-face :foreground blue)
+   (rainbow-delimiters-depth-8-face :foreground teal)
+   (rainbow-delimiters-depth-9-face :foreground dark-cyan)
+
+   ;; rjsx-mode
+   (rjsx-tag :foreground red)
+   (rjsx-attr :foreground yellow :slant 'italic :weight 'medium)
+
+   ;; tooltip
+   (tooltip              :background (doom-darken bg-alt 0.2) :foreground fg)))
+
+(provide 'doom-material-theme)

--- a/themes/doom-material-theme.el
+++ b/themes/doom-material-theme.el
@@ -17,8 +17,8 @@ Can be an integer to determine the exact padding."
   "A dark theme inspired by Material Theme by equinusocio"
 
   ;; name        default   256       16
-  ((bg         '("#1C262B" nil       nil))
-   (bg-alt     '("#263238" nil       nil))
+  ((bg         '("#263238" nil       nil))
+   (bg-alt     '("#1C262B" nil       nil))
    (base0      '("#171F24" "black"   "black"))
    (base1      '("#1C262B" "#262626" "brightblack"))
    (base2      '("#222D32" "#303030" "brightblack"))

--- a/themes/doom-material-theme.el
+++ b/themes/doom-material-theme.el
@@ -123,6 +123,8 @@ Can be an integer to determine the exact padding."
    (dired-k-ignored :foreground cyan)
    (dired-k-added    :foreground vc-added)
 
+   ;; ivy
+   (ivy-current-match :background base5)
 
    ;; js2-mode
    (js2-jsdoc-tag              :foreground magenta)


### PR DESCRIPTION
Closes #318.

Adds initial material theme, which is mostly the same as palenight theme with default material background.

(Future plans - configurable accent color, other material varations)