### PR TITLE
Increase salience of `helm-source-header`

### DIFF
--- a/doom-themes-base.el
+++ b/doom-themes-base.el
@@ -630,7 +630,7 @@
      (&dark  :distant-foreground highlight)
      (&light :distant-foreground base0))
     (helm-match :inherit 'bold :foreground highlight :distant-foreground base8)
-    (helm-source-header          :background base2 :foreground base5)
+    (helm-source-header          :background base2 :foreground keywords :weight 'bold)
     (helm-swoop-target-line-face :foreground highlight :inverse-video t)
     (helm-visible-mark           :inherit '(bold highlight))
     (helm-moccur-buffer          :inherit 'link)


### PR DESCRIPTION
Small change, makes it more clear which source one is looking at in a helm selection.