### PR TITLE
Extend the ivy-current-match background highlight to full line width

### DIFF
--- a/doom-themes-base.el
+++ b/doom-themes-base.el
@@ -699,7 +699,7 @@
     ((indent-guide-face &inherit highlight-indentation-face))
 
     ;; ivy
-    (ivy-current-match :background region :distant-foreground nil)
+    (ivy-current-match :background region :distant-foreground nil :extend t)
     (ivy-minibuffer-match-face-1
      :background nil
      :foreground (doom-lighten grey 0.14)


### PR DESCRIPTION
By making use of the new `:extend` keyword, we can make sure that the background highlight of the current ivy match doesn't end abruptly with the last word.
I've tested this small addition on my machine and it works as intended. Please consider the pull request. Cheers!