### PR TITLE
Add org-link styling for doom-challenger-deep

### DIFF
--- a/themes/doom-challenger-deep-theme.el
+++ b/themes/doom-challenger-deep-theme.el
@@ -158,6 +158,7 @@ determine the exact padding."
    ((org-block &override) :background base1)
    ((org-block-begin-line &override) :background base1 :foreground comments)
    (org-hide :foreground hidden)
+   (org-link :foreground orange :underline t :weight 'bold)
    (solaire-org-hide-face :foreground hidden)
 
    ;; tooltip


### PR DESCRIPTION
I'm overall pleased with the challenger-deep theme, but the default styling for org-link isn't outstanding enough.

Before:
![image](https://user-images.githubusercontent.com/1667473/72799283-d9c06800-3c7f-11ea-8400-258cf72d1fcf.png)

After:
![image](https://user-images.githubusercontent.com/1667473/72799328-f197ec00-3c7f-11ea-94aa-e76a11aebc99.png)
