### PR TITLE
fix region background from nord4 -> nord2 

### DIFF
--- a/themes/doom-nord-theme.el
+++ b/themes/doom-nord-theme.el
@@ -86,7 +86,7 @@ determine the exact padding."
    (region         (pcase doom-nord-region-highlight
                      (`frost teal)
                      (`snowstorm base7)
-                     (_ base4)))
+                     (_ base2)))
    (error          red)
    (warning        yellow)
    (success        green)


### PR DESCRIPTION
From https://www.nordtheme.com/docs/ports/emacs/configuration

> Region Highlight Style
> By default, Nord Emacs uses nord2 as background color for selected text in the editor to provide a sane default style.

It's way easier on the eye imho and matches the other nord themes packages.

Thanks for your work! I keep juggling between some of these themes. 