### PR TITLE
Set lsp-ui-doc-background to inherit from tooltip

### DIFF
--- a/doom-themes-base.el
+++ b/doom-themes-base.el
@@ -787,6 +787,7 @@
     (lsp-face-highlight-textual :background dark-blue :foreground base8 :distant-foreground base0 :weight 'bold)
     (lsp-face-highlight-read    :background dark-blue :foreground base8 :distant-foreground base0 :weight 'bold)
     (lsp-face-highlight-write   :background dark-blue :foreground base8 :distant-foreground base0 :weight 'bold)
+    (lsp-ui-doc-background :inherit 'tooltip)
     (lsp-ui-peek-filename :inherit 'mode-line-buffer-id)
     (lsp-ui-peek-header :foreground fg :background (doom-lighten bg 0.1) :bold bold)
     (lsp-ui-peek-selection :foreground bg :background blue :bold bold)


### PR DESCRIPTION
This sets up the background for lsp-ui-doc to be the same as tooltip.  This matches how the company-tooltip looks. 