### PR TITLE
Add org-journal calendar-entry face for doom-challenger-deep

### DIFF
--- a/themes/doom-challenger-deep-theme.el
+++ b/themes/doom-challenger-deep-theme.el
@@ -163,7 +163,12 @@ determine the exact padding."
    (solaire-org-hide-face :foreground hidden)
 
    ;; tooltip
-   (tooltip              :background base0 :foreground fg))
+   (tooltip              :background base0 :foreground fg)
+
+   ;; org-journal
+   (org-journal-calendar-entry-face :foreground orange))
+
+
 
   ;; --- extra variables ---------------------
   ;; ()


### PR DESCRIPTION
Gives it a nice orange, compared to the default dark-red:

![image](https://user-images.githubusercontent.com/1667473/74214005-9aad9180-4cd6-11ea-8790-123c5212fb39.png)
