### PR TITLE
[Horizon] Swap modeline active/inactive face

### DIFF
--- a/themes/doom-horizon-theme.el
+++ b/themes/doom-horizon-theme.el
@@ -100,8 +100,8 @@
       (when doom-horizon-padded-modeline
         (if (integerp doom-horizon-padded-modeline) doom-horizon-padded-modeline 4)))
 
-    (modeline-fg     (doom-lighten bg 0.2))
-    (modeline-fg-alt (doom-darken fg 0.2))
+    (modeline-fg     (doom-darken fg 0.2))
+    (modeline-fg-alt (doom-lighten bg 0.2))
 
     (modeline-bg
       (if -modeline-bright


### PR DESCRIPTION
Darkening the default foreground by 0.2 is actually still brighter than lightening the background by 0.2. Hence the former should be used when the modeline is active, and the latter for inactive.