### PR TITLE
Change Dracula's "type" color to violet

### DIFF
--- a/themes/doom-dracula-theme.el
+++ b/themes/doom-dracula-theme.el
@@ -78,7 +78,7 @@ determine the exact padding."
    (keywords       magenta)
    (methods        teal)
    (operators      violet)
-   (type           blue)
+   (type           violet)
    (strings        yellow)
    (variables      base8)
    (numbers        red)

--- a/themes/doom-dracula-theme.el
+++ b/themes/doom-dracula-theme.el
@@ -157,9 +157,9 @@ determine the exact padding."
 
    ;; --- major-mode faces -------------------
    ;; css-mode / scss-mode
-   (css-proprietary-property :foreground orange)
-   (css-property             :foreground green)
-   (css-selector             :foreground blue)
+   (css-proprietary-property :foreground violet)
+   (css-property             :foreground violet)
+   (css-selector             :foreground green)
 
    ;; markdown-mode
    (markdown-markup-face :foreground base5)
@@ -226,6 +226,8 @@ determine the exact padding."
    (web-mode-block-control-face :foreground orange)
    (web-mode-block-delimiter-face :foreground orange)
    (web-mode-builtin-face :foreground orange)
+   (web-mode-css-property-name-face :foreground violet)
+   (web-mode-css-selector-face :foreground green)
    (web-mode-html-attr-name-face :foreground violet)
    (web-mode-html-attr-value-face :foreground green)
    (web-mode-html-tag-bracket-face :inherit 'font-lock-comment-face)

--- a/themes/doom-dracula-theme.el
+++ b/themes/doom-dracula-theme.el
@@ -234,6 +234,10 @@ determine the exact padding."
    (web-mode-preprocessor-face :foreground orange)
    (web-mode-string-face :foreground yellow)
    (web-mode-type-face :foreground violet)
+
+   ;; highlight-quoted-mode
+   (highlight-quoted-symbol :foreground cyan)
+   (highlight-quoted-quote  :foreground magenta)
    )
 
   ;; --- extra variables ---------------------


### PR DESCRIPTION
This better matches Dracula's [official `font-lock-type-face`](https://github.com/dracula/emacs/blob/master/dracula-theme.el#L77). I realize this could have been overridden per-mode, but I can't find the current `blue`'s hex color anywhere in [Dracula's palette](https://github.com/dracula/dracula-theme#color-palette) and it's always stood out to me as not quite fitting the rest of the theme.

The overrides for `highlight-quoted-*` are also to better match the official theme.

`dracula`:

<img width="1552" alt="Dracula" src="https://user-images.githubusercontent.com/21947/74961823-9282df80-53c3-11ea-8296-a9b5aed39c45.png">

`doom-dracula` (current):

<img width="1552" alt="Doom Dracula" src="https://user-images.githubusercontent.com/21947/74961829-96aefd00-53c3-11ea-85fd-f4f56e3e9051.png">

`doom-dracula` (with these changes):

<img width="1552" alt="Updated Doom Dracula" src="https://user-images.githubusercontent.com/21947/74961837-9adb1a80-53c3-11ea-8872-716cea592f71.png">