### PR TITLE
Add theme rouge

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ DOOM Themes is an opinionated UI plugin and pack of themes extracted from my
   - [X] `doom-outrun-electric`: a neon colored theme inspired in VS Code's [Outrun Electric][outrun] (thanks to [ema2159])
   - [X] `doom-palenight` adapted from [Material Themes] (thanks to [Brettm12345])
   - [X] `doom-peacock`: based on Peacock from [daylerees' themes][daylerees] (thanks to [teesloane])
-  - [X] `doom-rouge`: based on [VSCode rouge theme][rouge theme]  (thanks to [JordanFaust])
+  - [X] `doom-rouge`: ported from [VSCode's Rouge Theme][rouge theme]  (thanks to [JordanFaust])
   - [X] `doom-snazzy`: a dark theme inspired in Atom's [Hyper Snazzy][snazzy] (thanks to [ar1a])
   - [X] `doom-solarized-dark`: dark variant of [Solarized][solarized] (thanks to [ema2159])
   - [X] `doom-solarized-light`: light variant of [Solarized][solarized] (thanks to [fuxialexander])

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ DOOM Themes is an opinionated UI plugin and pack of themes extracted from my
   - [X] `doom-outrun-electric`: a neon colored theme inspired in VS Code's [Outrun Electric][outrun] (thanks to [ema2159])
   - [X] `doom-palenight` adapted from [Material Themes] (thanks to [Brettm12345])
   - [X] `doom-peacock`: based on Peacock from [daylerees' themes][daylerees] (thanks to [teesloane])
+  - [X] `doom-rouge`: based on [VSCode rouge theme][rouge theme]  (thanks to [JordanFaust])
   - [X] `doom-snazzy`: a dark theme inspired in Atom's [Hyper Snazzy][snazzy] (thanks to [ar1a])
   - [X] `doom-solarized-dark`: dark variant of [Solarized][solarized] (thanks to [ema2159])
   - [X] `doom-solarized-light`: light variant of [Solarized][solarized] (thanks to [fuxialexander])
@@ -230,3 +231,5 @@ pointers. Additional theme and plugin support requests are welcome too.
 [ztlevi]: https://github.com/ztlevi
 [laserwave]: https://github.com/Jaredk3nt/laserwave
 [hyakt]: https://github.com/hyakt
+[rouge theme]: https://github.com/josefaidt/rouge-theme 
+[JordanFaust]: https://github.com/JordanFaust

--- a/doom-themes.el
+++ b/doom-themes.el
@@ -49,6 +49,7 @@
 ;;   [X] `doom-outrun' (added by ema2159)
 ;;   [X] `doom-palenight' (added by Brettm12345)
 ;;   [X] `doom-peacock' (added by teesloane)
+;;   [X] `doom-rouge' (added by JordanFaust)
 ;;   [X] `doom-snazzy' (added by ar1a)
 ;;   [X] `doom-solarized-dark' (added by ema2159)
 ;;   [X] `doom-solarized-light' (added by fuxialexnder)

--- a/themes/doom-rouge-theme.el
+++ b/themes/doom-rouge-theme.el
@@ -40,44 +40,44 @@ determine the exact padding."
    (base2      '("#151D2B" "#2e2e2e" "brightblack"  ))
    (base3      '("#172030" "#262626" "brightblack"  ))
    (base4      '("#5D636E" "#3f3f3f" "brightblack"  ))
-   (base5      '("#A2A6AC" "#64727d" "brightblack"  ))
-   (base6      '("#E8E9EA" "#6b6b6b" "brightblack"  ))
+   (base5      '("#64727d" "#64727d" "brightblack"  ))
+   (base6      '("#B16E75" "#6b6b6b" "brightblack"  ))
    (base7      '("#E8E9EB" "#979797" "brightblack"  ))
    (base8      '("#F0F4FC" "#dfdfdf" "white"        ))
-   (fg         '("#bbb"    "#bbb"    "white"        ))
+   (fg         '("#BBBBBB"    "#bbb"    "white"        ))
    (fg-alt     '("#E5E9F0" "#bfbfbf" "brightwhite"  ))
 
-   (grey       base4)
+   (grey       base5)
    (red        '("#c6797e" "#c6797e" "red"          ))
-   (light-red  '("#AD6A6E" "#C6878F" "red"          ))
+   (light-red  '("#DB6E8F" "#DB6E8F" "red"          ))
    (orange     '("#eabe9a" "#eabe9a" "brightred"    ))
-   (green      '("#969E92" "#ADB9A4" "green"        ))
-   (teal       '("#8FBCBB" "#44b9b1" "brightgreen"  ))
-   (yellow     '("#EBCB8B" "#ECBE7B" "yellow"       ))
-   (blue       '("#1E6378" "#51afef" "brightblue"   ))
-   (dark-blue  '("#91d1bd" "#91d1bd" "blue"         ))
-   (magenta    '("#4C4E78" "#b18bb1" "magenta"      ))
+   (green      '("#A3B09A" "#A3B9A4" "green"        ))
+   (teal       '("#7ea9a9" "#7ea9a9" "brightgreen"  ))
+   (yellow     '("#F7E3AF" "#F7E3AF" "yellow"       ))
+   (blue       '("#6e94b9" "#6e94b9" "brightblue"   ))
+   (dark-blue  '("#1E6378" "#1E6378" "blue"         ))
+   (magenta    '("#b18bb1" "#b18bb1" "magenta"      ))
    (salmon     '("#F9B5AC" "#F9B5AC" "orange"       ))
-   (violet     '("#5D80AE" "#a9a1e1" "brightmagenta"))
-   (cyan       '("#88C0D0" "#46D9FF" "brightcyan"   ))
-   (dark-cyan  '("#507681" "#5699AF" "cyan"         ))
+   (violet     '("#5D80AE" "#5D80AE" "brightmagenta"))
+   (cyan       '("#88C0D0" "#88C0D0" "brightcyan"   ))
+   (dark-cyan  '("#507681" "#507681" "cyan"         ))
 
    ;; face categories -- required for all themes
-   (highlight      red)
+   (highlight      base6)
    (vertical-bar   (doom-darken base1 0.2))
    (selection      base4)
-   (builtin        red)
-   (comments       (if doom-rouge-brighter-comments dark-cyan (doom-lighten base5 0.2)))
-   (doc-comments   (doom-lighten (if doom-rouge-brighter-comments dark-cyan base5) 0.25))
-   (constants      orange)
+   (builtin        light-red)
+   (comments       grey)
+   (doc-comments   green)
+   (constants      red)
    (functions      salmon)
    (keywords       magenta)
-   (methods        red)
-   (operators      green)
-   (type           red)
+   (methods        salmon)
+   (operators      magenta)
+   (type           magenta)
    (strings        green)
-   (variables      light-red)
-   (numbers        magenta)
+   (variables      red)
+   (numbers        orange)
    (region         base4)
    (error          red)
    (warning        yellow)
@@ -115,16 +115,14 @@ determine the exact padding."
    ((paren-face-mismatch &override) :foreground base3 :background red :weight 'ultra-bold)
    ((vimish-fold-overlay &override) :inherit 'font-lock-comment-face :background base3 :weight 'light)
    ((vimish-fold-fringe &override)  :foreground teal)
+   
+   ;; font-lock
+   (font-lock-keyword-face :slant 'italic :foreground keywords)
+   (font-lock-comment-face :foreground comments :slant 'italic)
+   (font-lock-doc-face :foreground doc-comments :slant 'italic)
+   (font-lock-preprocessor-face :foreground magenta :slant 'italic)
 
-   (font-lock-comment-face
-    :foreground comments
-    :background (if doom-rouge-comment-bg (doom-lighten bg 0.05)))
-   (font-lock-doc-face
-    :inherit 'font-lock-comment-face
-    :foreground doc-comments)
-
-   (doom-modeline-bar :background highlight)
-
+   ;; mode-line
    (mode-line
     :background modeline-bg :foreground modeline-fg
     :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg)))
@@ -134,7 +132,6 @@ determine the exact padding."
    (mode-line-emphasis
     :foreground highlight)
 
-   (doom-modeline-project-root-dir :foreground base6)
    (solaire-mode-line-face
     :inherit 'mode-line
     :background modeline-bg-l
@@ -143,6 +140,9 @@ determine the exact padding."
     :inherit 'mode-line-inactive
     :background modeline-bg-inactive-l
     :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg-inactive-l)))
+
+   ;; doom-modeline
+   (doom-modeline-project-root-dir :foreground base6)
 
    ;; ediff
    (ediff-fine-diff-A    :background (doom-darken violet 0.4) :weight 'bold)
@@ -179,3 +179,4 @@ determine the exact padding."
   )
 
 ;;; doom-rouge-theme.el ends here
+

--- a/themes/doom-rouge-theme.el
+++ b/themes/doom-rouge-theme.el
@@ -1,0 +1,182 @@
+;;; doom-rouge-theme.el --- inspired by Nord -*- no-byte-compile: t; -*-
+(require 'doom-themes)
+
+;;
+(defgroup doom-rouge-theme nil
+  "Options for doom-themes"
+  :group 'doom-themes)
+
+(defcustom doom-rouge-brighter-comments nil
+  "If non-nil, comments will be highlighted in more vivid colors."
+  :group 'doom-rouge-theme
+  :type 'boolean)
+
+(defcustom doom-rouge-brighter-tabs nil
+  "If non-nil, tabs will a more vivid background color."
+  :group 'doom-rouge-theme
+  :type 'boolean)
+
+(defcustom doom-rouge-comment-bg doom-rouge-brighter-comments
+  "If non-nil, comments will have a subtle, darker background. Enhancing their
+legibility."
+  :group 'doom-rouge-theme
+  :type 'boolean)
+
+(defcustom doom-rouge-padded-modeline doom-themes-padded-modeline
+  "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
+determine the exact padding."
+  :group 'doom-rouge-theme
+  :type '(choice integer boolean))
+
+;;
+(def-doom-theme doom-rouge
+  "A dark theme inspired by Nord."
+
+  ;; name        default   256       16
+  ((bg         '("#172030" nil       nil            )) ;; modified
+   (bg-alt     '("#172030" nil       nil            ))
+   (base0      '("#191C25" "black"   "black"        ))
+   (base1      '("#242832" "#1e1e1e" "brightblack"  ))
+   (base2      '("#2C333F" "#2e2e2e" "brightblack"  ))
+   (base3      '("#373E4C" "#262626" "brightblack"  ))
+   (base4      '("#434C5E" "#3f3f3f" "brightblack"  ))
+   (base5      '("#64727d" "#64727d" "brightblack"  ))
+   (base6      '("#9099AB" "#6b6b6b" "brightblack"  ))
+   (base7      '("#D8DEE9" "#979797" "brightblack"  ))
+   (base8      '("#F0F4FC" "#dfdfdf" "white"        ))
+   (fg         '("#bbb" "#bbb" "white"        ))
+   (fg-alt     '("#E5E9F0" "#bfbfbf" "brightwhite"  ))
+
+   (grey       base4)
+   (red        '("#c6797e" "#c6797e" "red"          ))
+   (light-red  '("#C6878F" "#C6878F" "red"          ))
+   (orange     '("#eabe9a" "#eabe9a" "brightred"    ))
+   (green      '("#ADB9A4" "#ADB9A4" "green"        ))
+   (teal       '("#8FBCBB" "#44b9b1" "brightgreen"  ))
+   (yellow     '("#EBCB8B" "#ECBE7B" "yellow"       ))
+   (blue       '("#81A1C1" "#51afef" "brightblue"   ))
+   (dark-blue  '("#91d1bd" "#91d1bd" "blue"         ))
+   (magenta     '("#b18bb1" "#b18bb1" "magenta"      ))
+   (salmon     '("#F9B5AC" "#F9B5AC" "orange"       ))
+   (violet     '("#5D80AE" "#a9a1e1" "brightmagenta"))
+   (cyan       '("#88C0D0" "#46D9FF" "brightcyan"   ))
+   (dark-cyan  '("#507681" "#5699AF" "cyan"         ))
+
+   ;; face categories -- required for all themes
+   (highlight      red)
+   (vertical-bar   (doom-darken base1 0.2))
+   (selection      base4)
+   (builtin        red)
+   (comments       (if doom-rouge-brighter-comments dark-cyan (doom-lighten base5 0.2)))
+   (doc-comments   (doom-lighten (if doom-rouge-brighter-comments dark-cyan base5) 0.25))
+   (constants      orange)
+   (functions      salmon)
+   (keywords       magenta)
+   (methods        red)
+   (operators      green)
+   (type           red)
+   (strings        green)
+   (variables      light-red)
+   (numbers        magenta)
+   (region         base4)
+   (error          red)
+   (warning        yellow)
+   (success        green)
+   (vc-modified    orange)
+   (vc-added       green)
+   (vc-deleted     red)
+
+   ;; custom categories
+   (hidden     `(,(car bg) "black" "black"))
+   (-modeline-pad
+    (when doom-rouge-padded-modeline
+      (if (integerp doom-rouge-padded-modeline) doom-rouge-padded-modeline 4)))
+
+   (tabs-bg (if doom-rouge-brighter-tabs red bg))
+   (tabs-bar-bg (if doom-rouge-brighter-tabs bg red))
+
+   (modeline-fg     nil)
+   (modeline-fg-alt base6)
+
+   (modeline-bg base1)
+   (modeline-bg-l `(,(doom-darken (car bg) 0.1) ,@(cdr base0)))
+   (modeline-bg-inactive   (doom-darken bg 0.1))
+   (modeline-bg-inactive-l `(,(car bg) ,@(cdr base1))))
+
+
+  ;; --- extra faces ------------------------
+  ((lazy-highlight :background base4)
+   (cursor :background red)
+
+
+   ((line-number &override) :foreground (doom-lighten 'base5 0.2))
+   ((line-number-current-line &override) :foreground base7)
+   ((paren-face-match &override) :foreground red :background base3 :weight 'ultra-bold)
+   ((paren-face-mismatch &override) :foreground base3 :background red :weight 'ultra-bold)
+   ((vimish-fold-overlay &override) :inherit 'font-lock-comment-face :background base3 :weight 'light)
+   ((vimish-fold-fringe &override)  :foreground teal)
+
+   (font-lock-comment-face
+    :foreground comments
+    :background (if doom-rouge-comment-bg (doom-lighten bg 0.05)))
+   (font-lock-doc-face
+    :inherit 'font-lock-comment-face
+    :foreground doc-comments)
+
+   (doom-modeline-bar :background highlight)
+
+   (mode-line
+    :background modeline-bg :foreground modeline-fg
+    :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg)))
+   (mode-line-inactive
+    :background modeline-bg-inactive :foreground modeline-fg-alt
+    :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg-inactive)))
+   (mode-line-emphasis
+    :foreground highlight)
+
+   (doom-modeline-project-root-dir :foreground base6)
+   (solaire-mode-line-face
+    :inherit 'mode-line
+    :background modeline-bg-l
+    :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg-l)))
+   (solaire-mode-line-inactive-face
+    :inherit 'mode-line-inactive
+    :background modeline-bg-inactive-l
+    :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg-inactive-l)))
+
+   ;; ediff
+   (ediff-fine-diff-A    :background (doom-darken violet 0.4) :weight 'bold)
+   (ediff-current-diff-A :background (doom-darken base0 0.25))
+
+   ;; elscreen
+   (elscreen-tab-other-screen-face :background "#353a42" :foreground "#1e2022")
+
+   ;; --- major-mode faces -------------------
+   ;; css-mode / scss-mode
+   (css-proprietary-property :foreground orange)
+   (css-property             :foreground green)
+   (css-selector             :foreground blue)
+
+   ;; markdown-mode
+   (markdown-markup-face :foreground base5)
+   (markdown-header-face :inherit 'bold :foreground red)
+   ((markdown-code-face &override) :background (doom-lighten base3 0.05))
+
+   ;; org-mode
+   (org-hide :foreground hidden)
+   (solaire-org-hide-face :foreground hidden)
+
+   ;; centuar-tabs
+   (centaur-tabs-selected :background tabs-bg)
+   (centaur-tabs-selected-modified :background tabs-bg)
+   (centaur-tabs-unselected-modified :background base0)
+   (centaur-tabs-active-bar-face :background tabs-bar-bg)
+
+   ;; neotree
+   (neo-root-dir-face :foreground red))
+
+  ;; --- extra variables ---------------------
+  ()
+  )
+
+;;; doom-rouge-theme.el ends here

--- a/themes/doom-rouge-theme.el
+++ b/themes/doom-rouge-theme.el
@@ -11,7 +11,7 @@
   :group 'doom-rouge-theme
   :type 'boolean)
 
-(defcustom doom-rouge-brighter-tabs nil
+(defcustom doom-rouge-brighter-tabs t
   "If non-nil, tabs will a more vivid background color."
   :group 'doom-rouge-theme
   :type 'boolean)
@@ -72,7 +72,7 @@ determine the exact padding."
    (constants      red)
    (functions      salmon)
    (keywords       magenta)
-   (methods        salmon)
+   (methods        light-red)
    (operators      magenta)
    (type           magenta)
    (strings        green)
@@ -92,7 +92,8 @@ determine the exact padding."
     (when doom-rouge-padded-modeline
       (if (integerp doom-rouge-padded-modeline) doom-rouge-padded-modeline 4)))
 
-   (tabs-bg (if doom-rouge-brighter-tabs red bg))
+   (tabs-bg (if doom-rouge-brighter-tabs base6 bg))
+   (tabs-fg (if doom-rouge-brighter-tabs base8 fg))
    (tabs-bar-bg (if doom-rouge-brighter-tabs bg red))
 
    (modeline-fg     nil)
@@ -167,9 +168,9 @@ determine the exact padding."
    (solaire-org-hide-face :foreground hidden)
 
    ;; centuar-tabs
-   (centaur-tabs-selected :background tabs-bg)
-   (centaur-tabs-selected-modified :background tabs-bg)
-   (centaur-tabs-unselected-modified :background bg)
+   (centaur-tabs-selected :foreground tabs-fg :background tabs-bg)
+   (centaur-tabs-selected-modified :foreground tabs-fg :background tabs-bg)
+   (centaur-tabs-unselected-modified :foreground tabs-fg :background bg)
    (centaur-tabs-active-bar-face :background tabs-bar-bg)
 
    ;; neotree
@@ -179,4 +180,3 @@ determine the exact padding."
   )
 
 ;;; doom-rouge-theme.el ends here
-

--- a/themes/doom-rouge-theme.el
+++ b/themes/doom-rouge-theme.el
@@ -35,28 +35,28 @@ determine the exact padding."
   ;; name        default   256       16
   ((bg         '("#172030" nil       nil            )) ;; modified
    (bg-alt     '("#172030" nil       nil            ))
-   (base0      '("#191C25" "black"   "black"        ))
-   (base1      '("#242832" "#1e1e1e" "brightblack"  ))
-   (base2      '("#2C333F" "#2e2e2e" "brightblack"  ))
-   (base3      '("#373E4C" "#262626" "brightblack"  ))
-   (base4      '("#434C5E" "#3f3f3f" "brightblack"  ))
-   (base5      '("#64727d" "#64727d" "brightblack"  ))
-   (base6      '("#9099AB" "#6b6b6b" "brightblack"  ))
-   (base7      '("#D8DEE9" "#979797" "brightblack"  ))
+   (base0      '("#070A0E" "black"   "black"        ))
+   (base1      '("#0E131D" "#1e1e1e" "brightblack"  ))
+   (base2      '("#151D2B" "#2e2e2e" "brightblack"  ))
+   (base3      '("#172030" "#262626" "brightblack"  ))
+   (base4      '("#5D636E" "#3f3f3f" "brightblack"  ))
+   (base5      '("#A2A6AC" "#64727d" "brightblack"  ))
+   (base6      '("#E8E9EA" "#6b6b6b" "brightblack"  ))
+   (base7      '("#E8E9EB" "#979797" "brightblack"  ))
    (base8      '("#F0F4FC" "#dfdfdf" "white"        ))
-   (fg         '("#bbb" "#bbb" "white"        ))
+   (fg         '("#bbb"    "#bbb"    "white"        ))
    (fg-alt     '("#E5E9F0" "#bfbfbf" "brightwhite"  ))
 
    (grey       base4)
    (red        '("#c6797e" "#c6797e" "red"          ))
-   (light-red  '("#C6878F" "#C6878F" "red"          ))
+   (light-red  '("#AD6A6E" "#C6878F" "red"          ))
    (orange     '("#eabe9a" "#eabe9a" "brightred"    ))
-   (green      '("#ADB9A4" "#ADB9A4" "green"        ))
+   (green      '("#969E92" "#ADB9A4" "green"        ))
    (teal       '("#8FBCBB" "#44b9b1" "brightgreen"  ))
    (yellow     '("#EBCB8B" "#ECBE7B" "yellow"       ))
-   (blue       '("#81A1C1" "#51afef" "brightblue"   ))
+   (blue       '("#1E6378" "#51afef" "brightblue"   ))
    (dark-blue  '("#91d1bd" "#91d1bd" "blue"         ))
-   (magenta     '("#b18bb1" "#b18bb1" "magenta"      ))
+   (magenta    '("#4C4E78" "#b18bb1" "magenta"      ))
    (salmon     '("#F9B5AC" "#F9B5AC" "orange"       ))
    (violet     '("#5D80AE" "#a9a1e1" "brightmagenta"))
    (cyan       '("#88C0D0" "#46D9FF" "brightcyan"   ))
@@ -106,7 +106,7 @@ determine the exact padding."
 
   ;; --- extra faces ------------------------
   ((lazy-highlight :background base4)
-   (cursor :background red)
+   (cursor :background green)
 
 
    ((line-number &override) :foreground (doom-lighten 'base5 0.2))
@@ -169,12 +169,11 @@ determine the exact padding."
    ;; centuar-tabs
    (centaur-tabs-selected :background tabs-bg)
    (centaur-tabs-selected-modified :background tabs-bg)
-   (centaur-tabs-unselected-modified :background base0)
+   (centaur-tabs-unselected-modified :background bg)
    (centaur-tabs-active-bar-face :background tabs-bar-bg)
 
    ;; neotree
    (neo-root-dir-face :foreground red))
-
   ;; --- extra variables ---------------------
   ()
   )

--- a/themes/doom-rouge-theme.el
+++ b/themes/doom-rouge-theme.el
@@ -109,6 +109,10 @@ determine the exact padding."
   ;; --- extra faces ------------------------
   ((lazy-highlight :background base4)
 
+   ;; ivy
+   (ivy-current-match :background base3)
+   (ivy-minibuffer-match-face-2 :foreground highlight :weight 'extra-bold)
+   
    ;; ivy-posframe
    (ivy-posframe :background bg-alt)
    (ivy-posframe-border :background highlight)
@@ -125,7 +129,9 @@ determine the exact padding."
    (font-lock-comment-face :foreground comments :slant 'italic)
    (font-lock-doc-face :foreground doc-comments :slant 'italic)
    (font-lock-preprocessor-face :foreground magenta :slant 'italic)
-
+   ;; vertical border
+   (vertical-border :foreground base6)
+   
    ;; mode-line
    (mode-line
     :background modeline-bg :foreground modeline-fg
@@ -166,6 +172,11 @@ determine the exact padding."
    (markdown-header-face :inherit 'bold :foreground red)
    ((markdown-code-face &override) :background (doom-lighten base3 0.05))
 
+   ;; magit
+   (magit-diff-hunk-heading           :foreground bg                    :background (doom-blend highlight bg 0.3) :extend t)
+   (magit-diff-hunk-heading-highlight :foreground bg                    :background highlight :weight 'bold :extend t)
+   (magit-section-heading :foreground highlight)
+   
    ;; org-mode
    (org-hide :foreground hidden)
    (solaire-org-hide-face :foreground hidden)

--- a/themes/doom-rouge-theme.el
+++ b/themes/doom-rouge-theme.el
@@ -38,14 +38,14 @@ determine the exact padding."
    (base0      '("#070A0E" "black"   "black"        ))
    (base1      '("#0E131D" "#1e1e1e" "brightblack"  ))
    (base2      '("#151D2B" "#2e2e2e" "brightblack"  ))
-   (base3      '("#172030" "#262626" "brightblack"  ))
+   (base3      '("#1F2A3F" "#262626" "brightblack"  ))
    (base4      '("#5D636E" "#3f3f3f" "brightblack"  ))
    (base5      '("#64727d" "#64727d" "brightblack"  ))
    (base6      '("#B16E75" "#6b6b6b" "brightblack"  ))
    (base7      '("#E8E9EB" "#979797" "brightblack"  ))
    (base8      '("#F0F4FC" "#dfdfdf" "white"        ))
-   (fg         '("#BBBBBB"    "#bbb"    "white"        ))
-   (fg-alt     '("#E5E9F0" "#bfbfbf" "brightwhite"  ))
+   (fg         '("#FAFFF6"    "#bbb"    "white"        ))
+   (fg-alt     '("#A7ACB9" "#bfbfbf" "brightwhite"  ))
 
    (grey       base5)
    (red        '("#c6797e" "#c6797e" "red"          ))
@@ -74,7 +74,7 @@ determine the exact padding."
    (keywords       magenta)
    (methods        light-red)
    (operators      magenta)
-   (type           magenta)
+   (type           red)
    (strings        green)
    (variables      red)
    (numbers        orange)
@@ -95,6 +95,7 @@ determine the exact padding."
    (tabs-bg (if doom-rouge-brighter-tabs base6 bg))
    (tabs-fg (if doom-rouge-brighter-tabs base8 fg))
    (tabs-bar-bg (if doom-rouge-brighter-tabs bg red))
+   (tabs-marker (if doom-rouge-brighter-tabs base8 highlight))
 
    (modeline-fg     nil)
    (modeline-fg-alt base6)
@@ -107,8 +108,10 @@ determine the exact padding."
 
   ;; --- extra faces ------------------------
   ((lazy-highlight :background base4)
-   (cursor :background green)
 
+   ;; ivy-posframe
+   (ivy-posframe :background bg-alt)
+   (ivy-posframe-border :background highlight)
 
    ((line-number &override) :foreground (doom-lighten 'base5 0.2))
    ((line-number-current-line &override) :foreground base7)
@@ -172,9 +175,14 @@ determine the exact padding."
    (centaur-tabs-selected-modified :foreground tabs-fg :background tabs-bg)
    (centaur-tabs-unselected-modified :foreground tabs-fg :background bg)
    (centaur-tabs-active-bar-face :background tabs-bar-bg)
+   (centaur-tabs-modified-marker-selected :inherit 'centaur-tabs-selected :foreground tabs-marker)
+   (centaur-tabs-modified-marker-unselected :inherit 'centaur-tabs-unselected :foreground tabs-marker)
 
    ;; neotree
-   (neo-root-dir-face :foreground red))
+   (neo-root-dir-face :foreground red)
+
+   ;; tooltip 
+   (tooltip :background base3 :foreground fg-alt))
   ;; --- extra variables ---------------------
   ()
   )

--- a/themes/doom-rouge-theme.el
+++ b/themes/doom-rouge-theme.el
@@ -1,4 +1,4 @@
-;;; doom-rouge-theme.el --- inspired by Nord -*- no-byte-compile: t; -*-
+;;; doom-rouge-theme.el --- ported from Rouge Theme -*- no-byte-compile: t; -*-
 (require 'doom-themes)
 
 ;;
@@ -30,7 +30,7 @@ determine the exact padding."
 
 ;;
 (def-doom-theme doom-rouge
-  "A dark theme inspired by Nord."
+  "A dark theme ported from VS Code's Rouge."
 
   ;; name        default   256       16
   ((bg         '("#172030" nil       nil            )) ;; modified


### PR DESCRIPTION
This is my first attempt at fully porting a theme. This is in reference to https://github.com/hlissner/emacs-doom-themes/issues/417

NOTE: this was ported from the nord theme as a base. Would have likely been better to start from the material theme. There might be a few colors left over from the nord theme that I was never able to surface through my workflows.

Variations from VSCode theme:
* Constants are 'orange' in this rather then 'yellow'. I used ruby as a base and it stayed closer to the overall look since constants and module/class definitions use a shared base.

I have only tested this with a few language modes (ruby elisp go). None of them are 100% matches. This is largely due to VSCode having more fine grained control over 'faces' in its supported languages

#  Rouge Theme
![image](https://user-images.githubusercontent.com/1653499/75994854-2f17a800-5ec1-11ea-8148-464604b95ca3.png)
