### PR TITLE
Change background of selection

### DIFF
--- a/themes/doom-monokai-pro-theme.el
+++ b/themes/doom-monokai-pro-theme.el
@@ -45,7 +45,7 @@ Can be an integer to determine the exact padding."
    ;; face categories
    (highlight      base8)
    (vertical-bar   (doom-lighten bg 0.1))
-   (selection      base4)
+   (selection      base5)
    (builtin        blue)
    (comments       grey)
    (doc-comments   yellow)


### PR DESCRIPTION
base4 is hard to distinguish from default background.
use base5 instead

screenshot for base4:
<img width="316" alt="图片" src="https://user-images.githubusercontent.com/1224321/79288555-a34e5e00-7ef9-11ea-93ed-9e7a3ce54d49.png">

screenshot for base5:
<img width="313" alt="图片" src="https://user-images.githubusercontent.com/1224321/79288422-45217b00-7ef9-11ea-9da9-edac7b5d733c.png">

