### PR TITLE
Fix fixed-pitch-serif face

### DIFF
--- a/themes/doom-acario-dark-theme.el
+++ b/themes/doom-acario-dark-theme.el
@@ -125,7 +125,7 @@ determine the exact padding."
 
 ;;;;; comments and doc
    (font-lock-comment-face
-    :inherit 'fixed-pitch-serif-face
+    :inherit 'fixed-pitch-serif
     :slant 'italic
     :foreground comments
     :background (if doom-acario-dark-comment-bg (doom-lighten bg 0.05)))
@@ -269,4 +269,3 @@ determine the exact padding."
   )
 
 ;;; doom-acario-dark-theme.el ends here
-

--- a/themes/doom-manegarm-theme.el
+++ b/themes/doom-manegarm-theme.el
@@ -110,7 +110,7 @@ real file buffers will now be brighter instead."
    ((line-number-current-line &override) :foreground orange)
 
    (font-lock-comment-face
-    :inherit 'fixed-pitch-serif-face
+    :inherit 'fixed-pitch-serif
     :slant 'italic
     :foreground comments
     :background nil)


### PR DESCRIPTION
I encountered an error while trying out the themes.

Seems that the face should be `fixed-pitch-serif` instead of `fixed-pitch-serif-face`.

Only the file `doom-acario-light-theme.el` has `fixed-pitch-serif` instead of `fixed-pitch-serif-face`, and I was able to use the theme successfully.