### PR TITLE
[WIP] Add Henna Theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ DOOM Themes is an opinionated UI plugin and pack of themes extracted from my
   - [X] `doom-ephemeral`: inspired in the Ephemeral Theme from [elenapan's dotfiles] (thanks to [karetsu])
   - [X] `doom-fairy-floss`: a candy colored Sublime theme by [sailorhg] (thanks to [ema2159])
   - [X] `doom-gruvbox`: adapted from Morhetz's [Gruvbox][gruvbox] (thanks to [JongW])
+  - [X] `doom-henna`: base on vscode-henna [Henna][henna] (thanks to [jsoa])
   - [X] `doom-horizon`: ported from VS Code's [Horizon][horizon] (thanks to [karetsu])
   - [X] `doom-Iosvkem`: adapted from [Iosvkem][Iosvkem] (thanks to [neutaaaaan])
   - [X] `doom-laserwave`: a clean 80's synthwave / outrun theme inspired by VS Code's [laserwave][laserwave] (thanks to [hyakt])
@@ -65,7 +66,6 @@ DOOM Themes is an opinionated UI plugin and pack of themes extracted from my
   - [X] `doom-wilmersdorf`: port of Ian Pan's [Wilmersdorf] (thanks to [ema2159])
   - [ ] `doom-mono-dark` / `doom-mono-light`: a minimalistic, monochromatic theme
   - [ ] `doom-tron`: based on Tron Legacy from [daylerees' themes][daylerees]
-  - [ ] `doom-henna`: base on vscode-henna
   
 ## Features
 
@@ -200,6 +200,7 @@ pointers. Additional theme and plugin support requests are welcome too.
 [fuxialexander]: https://github.com/fuxialexander
 [gagbo]: https://github.com/gagbo 
 [gruvbox]: https://github.com/morhetz/gruvbox
+[henna]: https://github.com/httpsterio/vscode-henna
 [horizon]: https://github.com/jolaleye/horizon-theme-vscode
 [hlinum]: https://melpa.org/#/hlinum
 [issues]: https://github.com/hlissner/emacs-doom-themes/issues

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ DOOM Themes is an opinionated UI plugin and pack of themes extracted from my
   - [X] `doom-wilmersdorf`: port of Ian Pan's [Wilmersdorf] (thanks to [ema2159])
   - [ ] `doom-mono-dark` / `doom-mono-light`: a minimalistic, monochromatic theme
   - [ ] `doom-tron`: based on Tron Legacy from [daylerees' themes][daylerees]
-
+  - [ ] `doom-henna`: base on vscode-henna
+  
 ## Features
 
 - `(doom-themes-visual-bell-config)`: flash the mode-line when the Emacs bell

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ pointers. Additional theme and plugin support requests are welcome too.
 [Iosvkem]: https://github.com/neutaaaaan/iosvkem
 [juanwolf]: https://github.com/juanwolf
 [JongW]: https://github.com/JongW
+[jsoa]: https://github.com/jsoa
 [jwintz]: https://github.com/jwintz
 [kadenbarlow]: https://github.com/kadenbarlow
 [karetsu]: https://github.com/karetsu

--- a/doom-themes.el
+++ b/doom-themes.el
@@ -33,6 +33,7 @@
 ;;   [X] `doom-ephemeral' (added by karetsu)
 ;;   [X] `doom-fairy-floss' (added by ema2159)
 ;;   [X] `doom-gruvbox' (added by JongW)
+;;   [X] `doom-henna' (added by jsoa)
 ;;   [X] `doom-horizon' (added by karetsu)
 ;;   [X] `doom-Iosvkem' (added by neutaaaaan)
 ;;   [X] `doom-laserwave' (added by hyakt)

--- a/themes/doom-henna-theme.el
+++ b/themes/doom-henna-theme.el
@@ -1,0 +1,259 @@
+;;; doom-henna-theme.el --- inspired by vscode henna theme -*- no-byte-compile: t; -*-
+(require 'doom-themes)
+
+;;; Code:
+(defgroup doom-henna-theme nil
+  "Options for doom-themes"
+  :group 'doom-themes)
+
+(defcustom doom-henna-brighter-modeline nil
+  "If non-nil, more vivid colors will be used to style the mode-line."
+  :group 'doom-henna-theme
+  :type 'boolean)
+
+(defcustom doom-henna-brighter-comments nil
+  "If non-nil, comments will be highlighted in more vivid colors."
+  :group 'doom-henna-theme
+  :type 'boolean)
+
+(defcustom doom-henna-comment-bg doom-henna-brighter-comments
+  "If non-nil, comments will have a subtle, darker background. Enhancing their
+legibility."
+  :group 'doom-henna-theme
+  :type 'boolean)
+
+(defcustom doom-henna-padded-modeline doom-themes-padded-modeline
+  "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
+determine the exact padding."
+  :group 'doom-henna-theme
+  :type '(choice integer boolean))
+
+;;
+(def-doom-theme doom-henna
+  "A dark theme inspired by Atom One Dark"
+
+  ;; name        default   256       16
+  ((bg         '("#21272e" nil       nil            ))
+   (bg-alt     '("#21242b" nil       nil            ))
+   (base0      '("#1B2229" "black"   "black"        ))
+   (base1      '("#181A1F" "#1e1e1e" "brightblack"  ))
+   (base2      '("#202328" "#2e2e2e" "brightblack"  ))
+   (base3      '("#23272e" "#262626" "brightblack"  ))
+   (base4      '("#606F73" "#3f3f3f" "brightblack"  ))
+   (base5      '("#5B6268" "#525252" "brightblack"  ))
+   (base6      '("#73797e" "#6b6b6b" "brightblack"  ))
+   (base7      '("#9ca0a4" "#979797" "brightblack"  ))
+   (base8      '("#DFDFDF" "#dfdfdf" "white"        ))
+   (fg         '("#f8f8f8" "#bfbfbf" "brightwhite"  ))
+   (fg-alt     '("#737c8c" "#979797" "white"        ))
+   (grey       base4)
+   (red        '("#e74c3c" "#ff6655" "red"          ))
+   (green      '("#53df83" "#99bb66" "green"        ))
+   (teal       '("#1abc9c" "#44b9b1" "brightgreen"))
+   (blue       '("#56b5c2" "#51afef" "brightblue"   ))
+   (cyan       '("#56b6c2" "#46D9FF" "brightcyan"   ))
+
+   ;; Not used
+   (orange     '("#da8548" "#dd8844" "brightred"    ))
+   (yellow     '("#ECBE7B" "#ECBE7B" "yellow"       ))
+   (magenta    '("#c678dd" "#c678dd" "brightmagenta"))
+   (violet     '("#a9a1e1" "#a9a1e1" "magenta"      ))
+   (dark-blue  '("#2257A0" "#2257A0" "blue"         ))
+   (dark-cyan  '("#5699AF" "#5699AF" "cyan"         ))
+
+   ;; custom
+   (green-alt  '("#9cd230"                          ))
+
+   ;; face categories -- required for all themes
+   (highlight      teal)
+   (vertical-bar   (doom-darken base1 0.1))
+   (selection      cyan)
+   (builtin        teal)
+   (comments       base4) ;;(if doom-henna-brighter-comments dark-cyan base5))
+   (doc-comments   green);; (doom-lighten (if doom-henna-brighter-comments dark-cyan base5) 0.25))
+   (constants      teal)
+   (functions      red)
+   (keywords       teal)
+   (methods        red)
+   (operators      red)
+   (type           red)
+   (strings        green)
+   (variables      fg)
+   (numbers        teal)
+   (region         (doom-darken dark-cyan 0.5)) ;;`(,(doom-lighten (car bg-alt) 0.15) ,@(doom-lighten (cdr base1) 0.35)))
+   (error          red)
+   (warning        yellow)
+   (success        green)
+   (vc-modified    blue)
+   (vc-added       green-alt)
+   (vc-deleted     (doom-darken red 0.2))
+
+   ;; custom categories
+   (hidden     `(,(car bg) "black" "black"))
+   (-modeline-bright doom-henna-brighter-modeline)
+   (-modeline-pad
+    (when doom-henna-padded-modeline
+      (if (integerp doom-henna-padded-modeline) doom-henna-padded-modeline 4)))
+
+
+   (modeline-fg     fg)
+   (modeline-fg-alt base5)
+
+   (modeline-bg
+    (if -modeline-bright
+        (doom-darken blue 0.475)
+      `(,(doom-darken (car bg-alt) 0.15) ,@(cdr base0))))
+   (modeline-bg-l
+    (if -modeline-bright
+        (doom-darken blue 0.45)
+      `(,(doom-darken (car bg-alt) 0.1) ,@(cdr base0))))
+   (modeline-bg-inactive   `(,(doom-darken (car bg-alt) 0.1) ,@(cdr bg-alt)))
+   (modeline-bg-inactive-l `(,(car bg-alt) ,@(cdr base1))))
+
+
+  ;; --- extra faces ------------------------
+
+  ;; Operator Fonts
+  ((elscreen-tab-other-screen-face :background "#353a42" :foreground "#1e2022")
+
+   (evil-goggles-default-face :inherit 'region :background (doom-blend region bg 0.5))
+
+   ((line-number &override) :foreground base5)
+   ((line-number-current-line &override) :foreground fg)
+
+   (hl-line :background "black")
+
+   (font-lock-operator-face
+    :foreground operators)
+
+   (font-lock-comment-face
+    :foreground comments
+    :background (if doom-henna-comment-bg (doom-lighten bg 0.05)))
+   (font-lock-doc-face
+    :inherit 'font-lock-comment-face
+    :foreground doc-comments)
+
+   (mode-line
+    :background modeline-bg :foreground modeline-fg
+    :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg)))
+   (mode-line-inactive
+    :background modeline-bg-inactive :foreground modeline-fg-alt
+    :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg-inactive)))
+   (mode-line-emphasis
+    :foreground (if -modeline-bright base8 highlight))
+
+   (solaire-mode-line-face
+    :inherit 'mode-line
+    :background modeline-bg-l
+    :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg-l)))
+   (solaire-mode-line-inactive-face
+    :inherit 'mode-line-inactive
+    :background modeline-bg-inactive-l
+    :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg-inactive-l)))
+   (solaire-default-face  :inherit 'default :background base1)
+
+   ;; hl-todo
+   (hl-todo :foreground red :weight 'bold)
+
+   ;; iedit
+   (iedit-occurrence :foreground blue :weight 'bold :inverse-video t)
+   (iedit-read-only-occurrence :inherit 'region)
+
+   ;; Doom modeline
+   (doom-modeline-bar :background (if -modeline-bright modeline-bg highlight))
+   (doom-modeline-buffer-file :inherit 'mode-line-buffer-id :weight 'bold)
+   (doom-modeline-buffer-path :inherit 'mode-line-emphasis :weight 'bold)
+   (doom-modeline-buffer-project-root :foreground green :weight 'bold)
+
+   ;; Doom dashboard
+   (doom-dashboard-banner      :foreground red)
+   (doom-dashboard-footer-icon :foreground green-alt)
+   (doom-dashboard-loaded      :foreground green-alt)
+
+   ;; which-key
+   (which-key-key-face                   :foreground red)
+   (which-key-group-description-face     :foreground green)
+   (which-key-command-description-face   :foreground teal)
+   (which-key-local-map-description-face :foreground green)
+
+   ;; ivy-mode
+   (ivy-minibuffer-match-highlight :foreground red)
+   (ivy-highlight-face :foreground red)
+   (ivy-minibuffer-match-face-2
+     :inherit 'ivy-minibuffer-match-face-1
+     :foreground red :background base1 :weight 'semi-bold)
+   (ivy-minibuffer-match-face-4
+     :inherit 'ivy-minibuffer-match-face-2
+     :foreground red :weight 'semi-bold)
+   (ivy-current-match :background dark-blue :distant-foreground base0 :weight 'normal)
+
+   ;; treemacs
+   (treemacs-directory-face    :foreground base8)
+   (treemacs-git-modified-face :foreground yellow)
+   (treemacs-file-face         :foreground base8)
+   (treemacs-root-face         :foreground red :weight 'bold)
+
+   ;; magit
+   (magit-section-heading :foreground red :weight 'bold)
+   (magit-tag             :foreground yellow)
+   (magit-filename        :foreground teal)
+
+   ;; Dired
+   (diredfl-date-time :foreground teal)
+   (diredfl-number    :foreground green)
+   (diredfl-dir-heading :foreground teal :weight 'bold)
+   
+   ;; --- major-mode faces -------------------
+
+   ;; css-mode / scss-mode
+   (css-proprietary-property :foreground cyan)
+   (css-property             :foreground teal)
+   (css-selector             :foreground red)
+
+   ;; markdown-mode
+   (markdown-markup-face           :foreground base5)
+   (markdown-header-face           :inherit 'bold :foreground red)
+   ((markdown-code-face &override) :background (doom-lighten base3 0.05))
+   (markdown-bold-face             :foreground blue :weight 'bold)
+
+   ;; org-mode
+   (org-hide              :foreground hidden)
+   (solaire-org-hide-face :foreground hidden)
+   (org-code              :foreground blue)
+
+   ;; outline
+   (outline-1 :foreground red                         :weight 'bold :extend t)
+   (outline-2 :foreground teal                        :weight 'bold :extend t)
+   (outline-3 :foreground green                       :weight 'bold :extend t)
+   (outline-4 :foreground (doom-lighten red 0.25)     :weight 'bold :extend t)
+   (outline-5 :foreground (doom-lighten green 0.25)   :weight 'bold :extend t)
+   (outline-6 :foreground (doom-lighten blue 0.5)     :weight 'bold :extend t)
+   (outline-7 :foreground (doom-lighten red 0.5)      :weight 'bold :extend t)
+   (outline-8 :foreground (doom-lighten blue 0.8)     :weight 'bold :extend t)
+
+   ;; web-mode
+   (web-mode-html-attr-equal-face  :foreground teal)
+   (web-mode-html-tag-face         :foreground green-alt)
+   (web-mode-html-tag-bracket-face :foreground teal)
+   (web-mode-keyword-face          :foreground teal)
+   (web-mode-block-control-face    :foreground red)
+   (web-mode-block-delimiter-face  :foreground teal)
+   (web-mode-variable-name-face    :foreground green)
+
+   ;; typescript
+   (typescript-access-modifier-face :foreground green-alt)
+   (typescript-this-face            :foreground green-alt)
+
+   ;; LSP
+   (lsp-face-highlight-textual :background "black")
+   (lsp-face-highlight-read    :background (doom-darken dark-blue 0.3))
+
+   ;; js
+   (js2-object-property :foregroun fg))
+
+  ;; --- extra variables ---------------------
+  ()
+
+  )
+
+;;; doom-henna-theme.el ends here

--- a/themes/doom-henna-theme.el
+++ b/themes/doom-henna-theme.el
@@ -58,7 +58,7 @@ determine the exact padding."
    (yellow     '("#ECBE7B" "#ECBE7B" "yellow"       ))
    (magenta    '("#30c965"))
    (violet     fg-alt)
-   (dark-blue  '("#5699AF" "#2257A0" "blue"         ))
+   (dark-blue  '("#2257A0" "#2257A0" "blue"         ))
    (dark-cyan  '("#5699AF" "#5699AF" "cyan"         ))
 
    ;; custom

--- a/themes/doom-henna-theme.el
+++ b/themes/doom-henna-theme.el
@@ -35,42 +35,43 @@ determine the exact padding."
   ;; name        default   256       16
   ((bg         '("#21272e" nil       nil            ))
    (bg-alt     '("#21242b" nil       nil            ))
-   (base0      '("#1B2229" "black"   "black"        ))
-   (base1      '("#181A1F" "#1e1e1e" "brightblack"  ))
-   (base2      '("#202328" "#2e2e2e" "brightblack"  ))
-   (base3      '("#23272e" "#262626" "brightblack"  ))
-   (base4      '("#606F73" "#3f3f3f" "brightblack"  ))
-   (base5      '("#5B6268" "#525252" "brightblack"  ))
-   (base6      '("#73797e" "#6b6b6b" "brightblack"  ))
-   (base7      '("#9ca0a4" "#979797" "brightblack"  ))
-   (base8      '("#DFDFDF" "#dfdfdf" "white"        ))
+   (base0      '("#10151a" "black"   "black"        ))
+   (base1      '("#181A1F" "#2e2e2e" "brightblack"  ))
+   (base2      '("#1B1F23" "#262626" "brightblack"  ))
+   (base3      '("#262D35" "#3f3f3f" "brightblack"  ))
+   (base4      '("#282C34" "#525252" "brightblack"  ))
+   (base5      '("#2c313a" "#6b6b6b" "brightblack"  ))
+   (base6      '("#3B4048" "#979797" "brightblack"  ))
+   (base7      '("#495162" "#dfdfdf" "white"        ))
+   (base8      '("#606F73" "#1e1e1e" "brightblack"  ))
    (fg         '("#f8f8f8" "#bfbfbf" "brightwhite"  ))
-   (fg-alt     '("#737c8c" "#979797" "white"        ))
-   (grey       base4)
+   (fg-alt     '("#6B717D" "#979797" "white"        ))
+   (grey       '("#737c8c"))
    (red        '("#e74c3c" "#ff6655" "red"          ))
    (green      '("#53df83" "#99bb66" "green"        ))
-   (teal       '("#1abc9c" "#44b9b1" "brightgreen"))
+   (teal       '("#1abc9c" "#44b9b1" "brightgreen"  ))
    (blue       '("#56b5c2" "#51afef" "brightblue"   ))
    (cyan       '("#56b6c2" "#46D9FF" "brightcyan"   ))
 
-   ;; Not used
-   (orange     '("#da8548" "#dd8844" "brightred"    ))
+   ;; Not used, so remap to other (henna) colors
+   (orange     '("#9cd230" "#dd8844" "brightred"    ))
    (yellow     '("#ECBE7B" "#ECBE7B" "yellow"       ))
-   (magenta    '("#c678dd" "#c678dd" "brightmagenta"))
-   (violet     '("#a9a1e1" "#a9a1e1" "magenta"      ))
-   (dark-blue  '("#2257A0" "#2257A0" "blue"         ))
+   (magenta    '("#30c965"))
+   (violet     fg-alt)
+   (dark-blue  '("#5699AF" "#2257A0" "blue"         ))
    (dark-cyan  '("#5699AF" "#5699AF" "cyan"         ))
 
    ;; custom
    (green-alt  '("#9cd230"                          ))
+   (green-dark '("#30c965"                          ))
 
    ;; face categories -- required for all themes
    (highlight      teal)
    (vertical-bar   (doom-darken base1 0.1))
    (selection      cyan)
    (builtin        teal)
-   (comments       base4) ;;(if doom-henna-brighter-comments dark-cyan base5))
-   (doc-comments   green);; (doom-lighten (if doom-henna-brighter-comments dark-cyan base5) 0.25))
+   (comments       base8) ;;(if doom-henna-brighter-comments dark-cyan base5))
+   (doc-comments   base8) ;; (doom-lighten (if doom-henna-brighter-comments dark-cyan base5) 0.25))
    (constants      teal)
    (functions      red)
    (keywords       teal)
@@ -85,7 +86,7 @@ determine the exact padding."
    (warning        yellow)
    (success        green)
    (vc-modified    blue)
-   (vc-added       green-alt)
+   (vc-added       orange)
    (vc-deleted     (doom-darken red 0.2))
 
    ;; custom categories
@@ -118,7 +119,7 @@ determine the exact padding."
 
    (evil-goggles-default-face :inherit 'region :background (doom-blend region bg 0.5))
 
-   ((line-number &override) :foreground base5)
+   ((line-number &override) :foreground base7)
    ((line-number-current-line &override) :foreground fg)
 
    (hl-line :background "black")
@@ -165,10 +166,19 @@ determine the exact padding."
    (doom-modeline-buffer-path :inherit 'mode-line-emphasis :weight 'bold)
    (doom-modeline-buffer-project-root :foreground green :weight 'bold)
 
+   ;; centaur
+   (centaur-tabs-selected :background base3 :foreground fg)
+   (centaur-tabs-unselected :background base2 :foreground grey)
+   (centaur-tabs-selected-modified :background bg :foreground orange)
+   (centaur-tabs-unselected-modified :background base1 :foreground magenta)
+   (centaur-tabs-active-bar-face :background green)
+   (centaur-tabs-modified-marker-selected :inherit 'centaur-tabs-selected-modified :foreground green)
+   (centaur-tabs-modified-marker-unselected :inherit 'centaur-tabs-unselected-modified :foreground green)
+
    ;; Doom dashboard
    (doom-dashboard-banner      :foreground red)
-   (doom-dashboard-footer-icon :foreground green-alt)
-   (doom-dashboard-loaded      :foreground green-alt)
+   (doom-dashboard-footer-icon :foreground orange)
+   (doom-dashboard-loaded      :foreground orange)
 
    ;; which-key
    (which-key-key-face                   :foreground red)
@@ -189,17 +199,25 @@ determine the exact padding."
 
    ;; treemacs
    (treemacs-directory-face    :foreground base8)
-   (treemacs-git-modified-face :foreground yellow)
+   (treemacs-git-modified-face :foreground orange)
    (treemacs-file-face         :foreground base8)
    (treemacs-root-face         :foreground red :weight 'bold)
 
    ;; magit
+   (magit-blame-headling     :foreground magenta :background base3)
+   (magit-cherry-equvalent   :foreground red)
+   (magit-log-author         :foreground magenta)
    (magit-section-heading    :foreground red :weight 'bold)
-   (magit-tag                :foreground (doom-lighten green-alt 0.5))
+   (magit-tag                :foreground (doom-lighten orange 0.5))
    (magit-filename           :foreground teal)
    (magit-diff-hunk-heading  :background (doom-darken teal 0.5))
    (magit-diff-hunk-heading-highlight :background (doom-darken teal 0.2))
-   (magit-branch-current     :foreground green-alt)
+   (magit-branch-current     :foreground orange)
+
+   ;; popup
+   (popup-tip-face :background base8 :foreground fg)
+   (popup-menu-mouse-face :background base8 :foreground fg)
+   (popup-summary-face :background base7 :foreground fg)
 
    ;; rainbow delimiters
    (rainbow-delimiters-depth-1-face :foreground red)
@@ -207,7 +225,7 @@ determine the exact padding."
    (rainbow-delimiters-depth-3-face :foreground teal)
    (rainbow-delimiters-depth-4-face :foreground green)
    (rainbow-delimiters-depth-5-face :foreground blue)
-   (rainbow-delimiters-depth-6-face :foreground green-alt)
+   (rainbow-delimiters-depth-6-face :foreground orange)
    (rainbow-delimiters-depth-7-face :foreground cyan)
 
    ;; Dired
@@ -245,7 +263,7 @@ determine the exact padding."
 
    ;; web-mode
    (web-mode-html-attr-equal-face  :foreground teal)
-   (web-mode-html-tag-face         :foreground green-alt)
+   (web-mode-html-tag-face         :foreground orange)
    (web-mode-html-tag-bracket-face :foreground teal)
    (web-mode-keyword-face          :foreground teal)
    (web-mode-block-control-face    :foreground red)
@@ -253,8 +271,8 @@ determine the exact padding."
    (web-mode-variable-name-face    :foreground (doom-lighten green 0.5))
 
    ;; typescript
-   (typescript-access-modifier-face :foreground green-alt)
-   (typescript-this-face            :foreground green-alt)
+   (typescript-access-modifier-face :foreground orange)
+   (typescript-this-face            :foreground orange)
 
    ;; LSP
    (lsp-face-highlight-textual :background "black")

--- a/themes/doom-henna-theme.el
+++ b/themes/doom-henna-theme.el
@@ -194,9 +194,12 @@ determine the exact padding."
    (treemacs-root-face         :foreground red :weight 'bold)
 
    ;; magit
-   (magit-section-heading :foreground red :weight 'bold)
-   (magit-tag             :foreground yellow)
-   (magit-filename        :foreground teal)
+   (magit-section-heading    :foreground red :weight 'bold)
+   (magit-tag                :foreground (doom-lighten green-alt 0.5))
+   (magit-filename           :foreground teal)
+   (magit-diff-hunk-heading  :background (doom-darken teal 0.5))
+   (magit-diff-hunk-heading-highlight :background (doom-darken teal 0.2))
+   (magit-branch-current     :foreground green-alt)
 
    ;; rainbow delimiters
    (rainbow-delimiters-depth-1-face :foreground red)
@@ -247,7 +250,7 @@ determine the exact padding."
    (web-mode-keyword-face          :foreground teal)
    (web-mode-block-control-face    :foreground red)
    (web-mode-block-delimiter-face  :foreground teal)
-   (web-mode-variable-name-face    :foreground green)
+   (web-mode-variable-name-face    :foreground (doom-lighten green 0.5))
 
    ;; typescript
    (typescript-access-modifier-face :foreground green-alt)

--- a/themes/doom-henna-theme.el
+++ b/themes/doom-henna-theme.el
@@ -198,6 +198,15 @@ determine the exact padding."
    (magit-tag             :foreground yellow)
    (magit-filename        :foreground teal)
 
+   ;; rainbow delimiters
+   (rainbow-delimiters-depth-1-face :foreground red)
+   (rainbow-delimiters-depth-2-face :foreground green)
+   (rainbow-delimiters-depth-3-face :foreground teal)
+   (rainbow-delimiters-depth-4-face :foreground green)
+   (rainbow-delimiters-depth-5-face :foreground blue)
+   (rainbow-delimiters-depth-6-face :foreground green-alt)
+   (rainbow-delimiters-depth-7-face :foreground cyan)
+
    ;; Dired
    (diredfl-date-time :foreground teal)
    (diredfl-number    :foreground green)
@@ -249,7 +258,11 @@ determine the exact padding."
    (lsp-face-highlight-read    :background (doom-darken dark-blue 0.3))
 
    ;; js
-   (js2-object-property :foregroun fg))
+   (js2-object-property :foreground fg)
+   (js2-object-property-access :foreground green)
+
+
+   )
 
   ;; --- extra variables ---------------------
   ()

--- a/themes/doom-henna-theme.el
+++ b/themes/doom-henna-theme.el
@@ -246,10 +246,21 @@ determine the exact padding."
    (css-selector             :foreground red)
 
    ;; markdown-mode
-   (markdown-markup-face           :foreground base5)
+   (markdown-markup-face           :foreground grey)
    (markdown-header-face           :inherit 'bold :foreground red)
    ((markdown-code-face &override) :background (doom-lighten base3 0.05))
-   (markdown-bold-face             :foreground blue :weight 'bold)
+   (markdown-bold-face             :foreground green :weight 'bold)
+   (markdown-url-face              :foreground fg :underline t)
+   (markdown-link-face             :foreground green)
+   (markdown-list-face             :foregroung fg)
+   (markdown-header-face-1         :foreground fg)
+   (markdown-header-face-2         :foreground fg)
+   (markdown-header-face-3         :foreground fg)
+   (markdown-header-face-4         :foreground fg)
+   (markdown-header-face-5         :foreground fg)
+   (markdown-header-face-6         :foreground fg)
+   (markdown-header-delimiter-face :foreground fg)
+   (markdown-inline-code-face      :foreground teal)
 
    ;; org-mode
    (org-hide              :foreground hidden)

--- a/themes/doom-henna-theme.el
+++ b/themes/doom-henna-theme.el
@@ -34,7 +34,7 @@ determine the exact padding."
 
   ;; name        default   256       16
   ((bg         '("#21272e" nil       nil            ))
-   (bg-alt     '("#21242b" nil       nil            ))
+   (bg-alt     '("#1B1F23" nil       nil            ))
    (base0      '("#10151a" "black"   "black"        ))
    (base1      '("#181A1F" "#2e2e2e" "brightblack"  ))
    (base2      '("#1B1F23" "#262626" "brightblack"  ))
@@ -44,7 +44,7 @@ determine the exact padding."
    (base6      '("#3B4048" "#979797" "brightblack"  ))
    (base7      '("#495162" "#dfdfdf" "white"        ))
    (base8      '("#606F73" "#1e1e1e" "brightblack"  ))
-   (fg         '("#f8f8f8" "#bfbfbf" "brightwhite"  ))
+   (fg         '("#f8f8f0" "#bfbfbf" "brightwhite"  ))
    (fg-alt     '("#6B717D" "#979797" "white"        ))
    (grey       '("#737c8c"))
    (red        '("#e74c3c" "#ff6655" "red"          ))
@@ -54,12 +54,12 @@ determine the exact padding."
    (cyan       '("#56b6c2" "#46D9FF" "brightcyan"   ))
 
    ;; Not used, so remap to other (henna) colors
-   (orange     '("#9cd230" "#dd8844" "brightred"    ))
+   (orange     red)
    (yellow     '("#ECBE7B" "#ECBE7B" "yellow"       ))
-   (magenta    '("#30c965"))
-   (violet     fg-alt)
+   (magenta    '("#FFB8D1" "#FFB8D1" "magenta"      ))
+   (violet     '("#C5A3FF" "#C5A3FF" "brightmagenta"))
    (dark-blue  '("#2257A0" "#2257A0" "blue"         ))
-   (dark-cyan  '("#5699AF" "#5699AF" "cyan"         ))
+   (dark-cyan  '("#2e4a54" "#204052" "cyan"         ))
 
    ;; custom
    (green-alt  '("#9cd230"                          ))
@@ -70,8 +70,8 @@ determine the exact padding."
    (vertical-bar   (doom-darken base1 0.1))
    (selection      cyan)
    (builtin        teal)
-   (comments       base8) ;;(if doom-henna-brighter-comments dark-cyan base5))
-   (doc-comments   base8) ;; (doom-lighten (if doom-henna-brighter-comments dark-cyan base5) 0.25))
+   (comments       base8)
+   (doc-comments   base8)
    (constants      teal)
    (functions      red)
    (keywords       teal)
@@ -81,7 +81,7 @@ determine the exact padding."
    (strings        green)
    (variables      fg)
    (numbers        teal)
-   (region         (doom-darken dark-cyan 0.5)) ;;`(,(doom-lighten (car bg-alt) 0.15) ,@(doom-lighten (cdr base1) 0.35)))
+   (region         dark-cyan)
    (error          red)
    (warning        yellow)
    (success        green)
@@ -266,6 +266,7 @@ determine the exact padding."
    (org-hide              :foreground hidden)
    (solaire-org-hide-face :foreground hidden)
    (org-code              :foreground blue)
+   (org-table             :foreground fg-alt)
 
    ;; outline
    (outline-1 :foreground red                         :weight 'bold :extend t)

--- a/themes/doom-henna-theme.el
+++ b/themes/doom-henna-theme.el
@@ -157,22 +157,22 @@ determine the exact padding."
    (hl-todo :foreground red :weight 'bold)
 
    ;; iedit
-   (iedit-occurrence :foreground blue :weight 'bold :inverse-video t)
-   (iedit-read-only-occurrence :inherit 'region)
+   (iedit-occurrence            :foreground blue :weight 'bold :inverse-video t)
+   (iedit-read-only-occurrence  :inherit 'region)
 
    ;; Doom modeline
-   (doom-modeline-bar :background (if -modeline-bright modeline-bg highlight))
-   (doom-modeline-buffer-file :inherit 'mode-line-buffer-id :weight 'bold)
-   (doom-modeline-buffer-path :inherit 'mode-line-emphasis :weight 'bold)
+   (doom-modeline-bar                 :background (if -modeline-bright modeline-bg highlight))
+   (doom-modeline-buffer-file         :inherit 'mode-line-buffer-id :weight 'bold)
+   (doom-modeline-buffer-path         :inherit 'mode-line-emphasis :weight 'bold)
    (doom-modeline-buffer-project-root :foreground green :weight 'bold)
 
    ;; centaur
-   (centaur-tabs-selected :background base3 :foreground fg)
-   (centaur-tabs-unselected :background base2 :foreground grey)
-   (centaur-tabs-selected-modified :background bg :foreground orange)
-   (centaur-tabs-unselected-modified :background base1 :foreground magenta)
-   (centaur-tabs-active-bar-face :background green)
-   (centaur-tabs-modified-marker-selected :inherit 'centaur-tabs-selected-modified :foreground green)
+   (centaur-tabs-selected                   :background base3 :foreground fg)
+   (centaur-tabs-unselected                 :background base2 :foreground grey)
+   (centaur-tabs-selected-modified          :background bg :foreground orange)
+   (centaur-tabs-unselected-modified        :background base1 :foreground magenta)
+   (centaur-tabs-active-bar-face            :background green)
+   (centaur-tabs-modified-marker-selected   :inherit 'centaur-tabs-selected-modified :foreground green)
    (centaur-tabs-modified-marker-unselected :inherit 'centaur-tabs-unselected-modified :foreground green)
 
    ;; Doom dashboard
@@ -187,8 +187,8 @@ determine the exact padding."
    (which-key-local-map-description-face :foreground green)
 
    ;; ivy-mode
-   (ivy-minibuffer-match-highlight :foreground red)
-   (ivy-highlight-face :foreground red)
+   (ivy-minibuffer-match-highlight  :foreground red)
+   (ivy-highlight-face              :foreground red)
    (ivy-minibuffer-match-face-2
      :inherit 'ivy-minibuffer-match-face-1
      :foreground red :background base1 :weight 'semi-bold)
@@ -198,26 +198,28 @@ determine the exact padding."
    (ivy-current-match :background dark-blue :distant-foreground base0 :weight 'normal)
 
    ;; treemacs
-   (treemacs-directory-face    :foreground base8)
-   (treemacs-git-modified-face :foreground orange)
-   (treemacs-file-face         :foreground base8)
-   (treemacs-root-face         :foreground red :weight 'bold)
+   (treemacs-directory-face     :foreground base8)
+   (treemacs-git-modified-face  :foreground yellow)
+   (treemacs-git-added-face     :foreground green)
+   (treemacs-git-untracked-face :foreground green-alt)
+   (treemacs-file-face          :foreground fg)
+   (treemacs-root-face          :foreground red :weight 'bold)
 
    ;; magit
-   (magit-blame-headling     :foreground magenta :background base3)
-   (magit-cherry-equvalent   :foreground red)
-   (magit-log-author         :foreground magenta)
-   (magit-section-heading    :foreground red :weight 'bold)
-   (magit-tag                :foreground (doom-lighten orange 0.5))
-   (magit-filename           :foreground teal)
-   (magit-diff-hunk-heading  :background (doom-darken teal 0.5))
+   (magit-blame-headling              :foreground magenta :background base3)
+   (magit-cherry-equvalent            :foreground red)
+   (magit-log-author                  :foreground magenta)
+   (magit-section-heading             :foreground red :weight 'bold)
+   (magit-tag                         :foreground (doom-lighten orange 0.5))
+   (magit-filename                    :foreground teal)
+   (magit-diff-hunk-heading           :background (doom-darken teal 0.5))
    (magit-diff-hunk-heading-highlight :background (doom-darken teal 0.2))
-   (magit-branch-current     :foreground orange)
+   (magit-branch-current              :foreground orange)
 
    ;; popup
-   (popup-tip-face :background base8 :foreground fg)
+   (popup-tip-face        :background base8 :foreground fg)
    (popup-menu-mouse-face :background base8 :foreground fg)
-   (popup-summary-face :background base7 :foreground fg)
+   (popup-summary-face    :background base7 :foreground fg)
 
    ;; rainbow delimiters
    (rainbow-delimiters-depth-1-face :foreground red)
@@ -229,9 +231,9 @@ determine the exact padding."
    (rainbow-delimiters-depth-7-face :foreground cyan)
 
    ;; Dired
-   (diredfl-date-time :foreground teal)
-   (diredfl-number    :foreground green)
-   (diredfl-dir-heading :foreground teal :weight 'bold)
+   (diredfl-date-time    :foreground teal)
+   (diredfl-number       :foreground green)
+   (diredfl-dir-heading  :foreground teal :weight 'bold)
    
    ;; --- major-mode faces -------------------
 
@@ -279,7 +281,7 @@ determine the exact padding."
    (lsp-face-highlight-read    :background (doom-darken dark-blue 0.3))
 
    ;; js
-   (js2-object-property :foreground fg)
+   (js2-object-property        :foreground fg)
    (js2-object-property-access :foreground green)
 
 

--- a/themes/doom-henna-theme.el
+++ b/themes/doom-henna-theme.el
@@ -186,6 +186,9 @@ determine the exact padding."
    (which-key-command-description-face   :foreground teal)
    (which-key-local-map-description-face :foreground green)
 
+   ;; highlight-numbers
+   (highlight-numbers-number :foreground blue)
+
    ;; ivy-mode
    (ivy-minibuffer-match-highlight  :foreground red)
    (ivy-highlight-face              :foreground red)
@@ -281,10 +284,12 @@ determine the exact padding."
    (lsp-face-highlight-read    :background (doom-darken dark-blue 0.3))
 
    ;; js
-   (js2-object-property        :foreground fg)
-   (js2-object-property-access :foreground green)
-
-
+   (js2-object-property          :foreground fg)
+   (js2-object-property-access   :foreground green)
+   (js2-jsdoc-value              :foreground red)
+   (js2-jsdoc-tag                :foreground teal)
+   (js2-jsdoc-html-tag-delimiter :foreground base8)
+   (js2-jsdoc-html-tag-name      :foreground base8)
    )
 
   ;; --- extra variables ---------------------


### PR DESCRIPTION
This is my first attempt at converting a theme, and I echo the comments by @JordanFaust [here](https://github.com/hlissner/emacs-doom-themes/pull/418#issue-383952353) about this not being a 100% 1 to 1 match to the vscode original. 

- fixes: #426 
- **Base theme used**: `doom-one`

**Todo**
- [ ] 256/16 bit color support

I only tested in a couple modes, here is a checklist..
- [x] elisp-mode
- [x] python-mode
- [x] web-mode
- [x] typescript-mode
- [x] css/scss mode
- [ ] cpp (not something I program in) (@Marcos-H needs verification perhaps)
- [x] org-mode
- [x] markdown-mode
- [x] rainbow delimters
- [x] js2-mode (WIP)
- [x] mu4e
- [x] pass
- [x] magit
- [x] treemacs
- [x] undo-tree-visualizer

screenshots below showcases some of the areas I focused on.

**general**
![2020-04-18_12:05:10](https://user-images.githubusercontent.com/23966/79642855-df89f480-816d-11ea-9824-e71136d70181.png)

`magit`
![2020-04-18_21:55:15](https://user-images.githubusercontent.com/23966/79677455-c0b44e00-81bf-11ea-9b3f-44559175b34b.png)

`python-mode`
![2020-04-18_11:46:02](https://user-images.githubusercontent.com/23966/79642894-00524a00-816e-11ea-9f38-c28e881bcbac.png)

`web-mode`
![2020-04-18_22:05:57](https://user-images.githubusercontent.com/23966/79677567-dd9d5100-81c0-11ea-8967-766cfe1e521b.png)

`cpp-mode` 
![2020-04-18_11:47:52](https://user-images.githubusercontent.com/23966/79642912-1233ed00-816e-11ea-8acd-81535a492418.png)

`org`
![2020-04-18_12:17:43](https://user-images.githubusercontent.com/23966/79642989-a605b900-816e-11ea-835b-d0e7dfc67cd7.png)

`which-key`
![2020-04-18_11:45:04](https://user-images.githubusercontent.com/23966/79642914-1d871880-816e-11ea-85e3-b588bc41b9e2.png)

`search`
![2020-04-18_11:43:20](https://user-images.githubusercontent.com/23966/79642929-40193180-816e-11ea-8061-f6cceab69cd3.png)

`splash`
![2020-04-18_11:28:36](https://user-images.githubusercontent.com/23966/79642938-4d362080-816e-11ea-9ced-89c6fa63a7fd.png)
