### PR TITLE
[405][spacegray] Fix issues with visible asterisks

### DIFF
--- a/themes/doom-spacegrey-theme.el
+++ b/themes/doom-spacegrey-theme.el
@@ -170,7 +170,7 @@ determine the exact padding."
    ((org-quote &override) :background base1)
 
    ;; org-mode
-   (org-hide :foreground hidden)
+   (org-hide :foreground bg)
    (solaire-org-hide-face :foreground hidden)
 
    (tooltip              :background bg-alt :foreground fg))


### PR DESCRIPTION
The code in this change set fixes #405 (sets `org-hide`) to `bg`

- Tested with both `solaire-mode` on and off
![2020-04-29_00:05:34](https://user-images.githubusercontent.com/23966/80559951-3503a400-89ad-11ea-8cd2-2c26f98fc4f8.png)
