### PR TITLE
Minor face improvements for doom-one and doom-gruvbox

### DIFF
--- a/themes/doom-gruvbox-theme.el
+++ b/themes/doom-gruvbox-theme.el
@@ -91,7 +91,7 @@ determine the exact padding."
    (org-quote `(,(doom-lighten (car bg) 0.05) "#1f1f1f")))
 
   ;; --- extra faces ------------------------
-(
+  (
    ;;;;;;;; Editor ;;;;;;;;
    (cursor :background "white")
    (hl-line :background bg-alt)
@@ -232,10 +232,16 @@ determine the exact padding."
    (magit-diff-hunk-heading-highlight :background accent :foreground fg)
    (magit-diff-context                :foreground bg-alt :foreground fg-alt)
 
- 
+
    ;;;;;;;; Major mode faces ;;;;;;;;
    ;; css-mode / scss-mode
    (css-proprietary-property :foreground keywords)
+
+   ;; elisp-mode
+   (highlight-quoted-symbol :foreground dark-cyan)
+
+   ;; LaTeX-mode
+   (font-latex-math-face :foreground dark-cyan)
 
    ;; markdown-mode
    (markdown-blockquote-face :inherit 'italic :foreground cyan)
@@ -244,6 +250,9 @@ determine the exact padding."
    (markdown-pre-face  :foreground green)
    (markdown-link-face :inherit 'bold :foreground cyan)
    ((markdown-code-face &override) :background (doom-lighten base2 0.045))
+
+   ;; mu4e-view
+   (mu4e-header-key-face :foreground red)
 
    ;; org-mode
    ((outline-1 &override) :foreground yellow)

--- a/themes/doom-one-theme.el
+++ b/themes/doom-one-theme.el
@@ -154,6 +154,9 @@ determine the exact padding."
    (css-property             :foreground green)
    (css-selector             :foreground blue)
 
+   ;; LaTeX-mode
+   (font-latex-math-face :foreground green)
+
    ;; markdown-mode
    (markdown-markup-face :foreground base5)
    (markdown-header-face :inherit 'bold :foreground red)


### PR DESCRIPTION
## doom-one
Since latex' math-mode and keywords share the same color, I changed the one of math-mode to green (which IMO looks pretty neat).
![onelatex](https://user-images.githubusercontent.com/33008303/80809990-268ed580-8bc3-11ea-9860-4ff45ceee677.png)
![onelatex2](https://user-images.githubusercontent.com/33008303/80810000-2bec2000-8bc3-11ea-8428-b1a2d6964d6d.png)

## doom-gruvbox
So far quoted elisp symbols and function names shared the same color. I made use of dark-cyan to make them distinguishable.
![gruvbox1](https://user-images.githubusercontent.com/33008303/80810154-81283180-8bc3-11ea-8ffb-a0c9a28fc83d.png)
![gruvelisp2](https://user-images.githubusercontent.com/33008303/80810171-8b4a3000-8bc3-11ea-93dc-dacce94d1486.png)

The headers of a mail opened in view mode look pretty uniform. I spiced up the keys with red, to make it more readable.
![gruvmu4e](https://user-images.githubusercontent.com/33008303/80810400-0b709580-8bc4-11ea-94c0-b75e20d9ebb4.png)
![gruvmu4e2](https://user-images.githubusercontent.com/33008303/80810408-10354980-8bc4-11ea-9973-a2ef56662c4b.png)

This one is a bit more opinionated. Latex' math-mode uses blue as its face. I think it doesn't really complement the pastel look of the theme, and thus changed it  to dark-cyan.
![gruvlatex1](https://user-images.githubusercontent.com/33008303/80810513-4b377d00-8bc4-11ea-90b7-7be29de9a84a.png)
![gruvlatex2](https://user-images.githubusercontent.com/33008303/80810525-54c0e500-8bc4-11ea-8726-aad84541dd24.png)
