### PR TITLE
Add deadgrep-match-face to monokai pro and spectrum themes

### DIFF
--- a/themes/doom-monokai-pro-theme.el
+++ b/themes/doom-monokai-pro-theme.el
@@ -85,6 +85,9 @@ Can be an integer to determine the exact padding."
    (lazy-highlight                               :inherit 'match)
    (isearch-fail                                 :foreground red)
 
+   ;; deadgrep
+   (deadgrep-match-face                          :inherit 'match :box `(:line-width 2 :color ,yellow))
+
    ;; swiper
    (swiper-background-match-face-1               :inherit 'match :bold bold)
    (swiper-background-match-face-2               :inherit 'match)

--- a/themes/doom-monokai-spectrum-theme.el
+++ b/themes/doom-monokai-spectrum-theme.el
@@ -99,6 +99,9 @@ determine the exact padding."
    (lazy-highlight                               :inherit 'match)
    (isearch-fail                                 :foreground red)
 
+   ;; deadgrep
+   (deadgrep-match-face                          :inherit 'match :box `(:line-width 2 :color ,yellow))
+
    ;; mode-line
    (mode-line                                    :background base3 :foreground fg
                                                  :box (if -modeline-pad `(:line-width ,-modeline-pad :color red)))


### PR DESCRIPTION
I'm not sure if a PR like this is acceptable, given that [deadgrep](https://github.com/Wilfred/deadgrep) isn't included in doom emacs by default, but I'm trying my luck!

P.S. deadgrep is awesome! I'd be keen to write a module for it.