### PR TITLE
Fix almost invisible faces in notmuch mail (doom-solarized)

### DIFF
--- a/themes/doom-solarized-light-theme.el
+++ b/themes/doom-solarized-light-theme.el
@@ -203,6 +203,10 @@ determine the exact padding."
    ;; latex
    (font-latex-sedate-face :foreground base6)
 
+   ;; notmuch
+   (notmuch-message-summary-face :foreground teal)
+   (notmuch-wash-cited-text :foreground base6)
+
    )
 
 


### PR DESCRIPTION
Mail header and cited text is barely visible, the suggested colours are better.

Thanks.