### PR TITLE
Fix internal README links for one-light & vibrant

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 - [Flagship Themes](#flagship-themes)
     - [doom-one](#doom-one)
-    - [doom-one-light (WIP)](#doom-one-light-wip)
-    - [doom-vibrant (WIP)](#doom-vibrant-wip)
+    - [doom-one-light (WIP)](#doom-one-light)
+    - [doom-vibrant (WIP)](#doom-vibrant)
 - [Additional Themes](#additional-themes)
     - [doom-acario-dark](#doom-acario-dark)
     - [doom-acario-light](#doom-acario-light)


### PR DESCRIPTION
Links for doom-one-light and doom-vibrant had a trailing '-wip' whereas the targets didn't.