### PR TITLE
doom-themes-base: separate header-line and mode-line

### DIFF
--- a/doom-themes-base.el
+++ b/doom-themes-base.el
@@ -56,7 +56,7 @@
     (mode-line-emphasis  :foreground highlight :distant-foreground bg)
     (mode-line-highlight :inherit 'highlight :distant-foreground bg)
     (mode-line-buffer-id :weight 'bold)
-    (header-line :inherit 'mode-line :distant-foreground bg)
+    (header-line         :background bg     :foreground fg     :distant-foreground bg)
 
     ;; 1. Line number faces must explicitly disable its text style attributes
     ;;    because nearby faces may "bleed" into the line numbers otherwise.


### PR DESCRIPTION
Fix #473