### PR TITLE
Add hard/soft contrast options for gruvbox dark

### DIFF
--- a/themes/doom-gruvbox-light-theme.el
+++ b/themes/doom-gruvbox-light-theme.el
@@ -29,8 +29,8 @@ determine the exact padding."
   :type '(choice integer boolean))
 
 (defcustom doom-gruvbox-light-variant nil
-  "If non-nil, choice of hard or medium can be use to change the
-variant. Defaults to medium."
+  "A choice of \"hard\" or \"soft\" can be used to change the
+background contrast. All other values default to \"medium\"."
   :group 'doom-gruvbox-light-theme
   :type  'string)
 
@@ -40,13 +40,13 @@ variant. Defaults to medium."
 
   ;; name        default   256       16
   ((bg
-    (cond ((equal doom-gruvbox-light-variant "hard") '("#f9f5d7" "#ffffd7" nil))    ;; gruvbox-dark0_hard
-          ((equal doom-gruvbox-light-variant "soft") '("#f2e5bc" "#ffffd7" nil))  ;; gruvbox-dark0
-          (t '("#fbf1c7" "#ffffd7" nil))))                                          ;; gruvbox-dark0_soft
+    (cond ((equal doom-gruvbox-light-variant "hard") '("#f9f5d7" "#ffffd7" nil))   ; bg0_h
+          ((equal doom-gruvbox-light-variant "soft") '("#f2e5bc" "#ffffd7" nil))   ; bg0_s
+          (t                                         '("#fbf1c7" "#ffffd7" nil)))) ; bg0
    (bg-alt
-    (cond ((equal doom-gruvbox-light-variant "hard")    '("#fbf1c7" "#ffffd7" nil)) ;; gruvbox-dark0
-          ((equal doom-gruvbox-light-variant "soft")  '("#ebdbb2" "#ffffaf" nil)) ;; gruvbox-dark0_soft
-          (t '("#f2e5bc" "#ffffd7" nil))))                                          ;; gruvbox-dark1
+    (cond ((equal doom-gruvbox-light-variant "hard") '("#fbf1c7" "#ffffd7" nil))
+          ((equal doom-gruvbox-light-variant "soft") '("#ebdbb2" "#ffffaf" nil))
+          (t                                         '("#f2e5bc" "#ffffd7" nil))))
    (base0      '("#f0f0f0" "#f0f0f0" "white"           )) ;;
    (base1      '("#ebdbb2" "#ffffaf" "brightblack"     )) ;; gruvbox-dark1
    (base2      '("#d5c4a1" "#d7d6af" "brightblack"     )) ;; gruvbox-dark2
@@ -390,7 +390,7 @@ variant. Defaults to medium."
    (rainbow-delimiters-depth-11-face :foreground delimiter-3)
    (rainbox-delimiters-depth-12-face :foreground faded-orange)
    (rainbow-delimiters-unmatched-face: :foreground fg :background 'nil)
-   
+
    ;; swiper
    (swiper-line-face    :background base3 :foreground base0)
    (swiper-match-face-1 :inherit 'unspecified :background base1   :foreground base5)

--- a/themes/doom-gruvbox-theme.el
+++ b/themes/doom-gruvbox-theme.el
@@ -265,6 +265,12 @@ background contrast. All other values default to \"medium\"."
    ;; elisp-mode
    (highlight-quoted-symbol :foreground dark-cyan)
 
+   ;; highlight-symbol
+   (highlight-symbol-face :background (doom-lighten base3 0.03) :distant-foreground fg-alt)
+
+   ;; highlight-thing
+   (highlight-thing :background (doom-lighten base3 0.03) :distant-foreground fg-alt)
+
    ;; LaTeX-mode
    (font-latex-math-face :foreground dark-cyan)
 

--- a/themes/doom-gruvbox-theme.el
+++ b/themes/doom-gruvbox-theme.el
@@ -68,20 +68,6 @@ background contrast. All other values default to \"medium\"."
    (cyan       '("#8ec07c" "#8ec07c" "brightcyan"))    ; bright-aqua
    (dark-cyan  '("#689d6a" "#689d6a" "cyan"))          ; aqua
 
-   ;; Extra
-   (aqua      '("#8ec07c" "#8ec07c" "brightcyan"))  ; bright-aqua
-   (dark-aqua '("#689d6a" "#689d6a" "cyan"))        ; aqua
-   (bg0       '("#282828" "#282828" "brightblack")) ; bg0
-   (bg1       '("#3c3836" "#383838" "brightblack")) ; bg1
-   (bg2       '("#504945" "#494949" "brightblack")) ; bg2
-   (bg3       '("#665c54" "#5c5c5c" "brightblack")) ; bg3
-   (bg4       '("#7c6f64" "#6f6f6f" "brightblack")) ; bg4
-   (fg0       '("#fbf1c7" "#fbfbfb" "brightwhite")) ; fg0
-   (fg1       '("#ebdbb2" "#dfdfdf" "brightwhite")) ; fg/fg1
-   (fg2       '("#d5c4a1" "#cccccc" "brightblack")) ; fg2
-   (fg3       '("#bdae93" "#bdbdbd" "brightblack")) ; fg3
-   (fg4       '("#a89984" "#999999" "brightblack")) ; fg4
-
    ;; face categories
    (highlight      yellow)
    (vertical-bar   grey)
@@ -90,9 +76,9 @@ background contrast. All other values default to \"medium\"."
    (comments       (if doom-gruvbox-brighter-comments magenta grey))
    (doc-comments   (if doom-gruvbox-brighter-comments (doom-lighten magenta 0.2) (doom-lighten fg-alt 0.25)))
    (constants      violet)
-   (functions      aqua)
+   (functions      cyan)
    (keywords       red)
-   (methods        aqua)
+   (methods        cyan)
    (operators      cyan)
    (type           yellow)
    (strings        green)
@@ -121,7 +107,7 @@ background contrast. All other values default to \"medium\"."
    ;;;;;;;; Editor ;;;;;;;;
    (cursor :background "white")
    (hl-line :background bg-alt)
-   ((line-number &override) :foreground bg4)
+   ((line-number &override) :foreground base5)
    ((line-number-current-line &override) :background bg-alt2 :foreground fg :bold t)
 
    ;; Vimish-fold
@@ -156,14 +142,14 @@ background contrast. All other values default to \"medium\"."
    (isearch :foreground base0 :background orange)
    (evil-search-highlight-persist-highlight-face :background yellow)
    (lazy-highlight :background yellow :foreground base0 :distant-foreground base0 :bold bold)
-   (evil-ex-substitute-replacement :foreground aqua :inherit 'evil-ex-substitute-matches)
+   (evil-ex-substitute-replacement :foreground cyan :inherit 'evil-ex-substitute-matches)
 
    ;; evil-snipe
    (evil-snipe-first-match-face :foreground "white" :background yellow)
    (evil-snipe-matches-face     :foreground yellow :bold t :underline t)
 
    ;;;;;;;; Mini-buffers ;;;;;;;;
-   (minibuffer-prompt :foreground aqua)
+   (minibuffer-prompt :foreground cyan)
    (solaire-hl-line-face :background bg-alt2)
 
    ;; ivy
@@ -173,8 +159,8 @@ background contrast. All other values default to \"medium\"."
    (ivy-grep-line-number :background nil :foreground cyan)
    (ivy-minibuffer-match-face-1 :background nil :foreground yellow)
    (ivy-minibuffer-match-face-2 :background nil :foreground yellow)
-   (ivy-minibuffer-match-highlight :foreground aqua)
-   (counsel-key-binding :foreground aqua)
+   (ivy-minibuffer-match-highlight :foreground cyan)
+   (counsel-key-binding :foreground cyan)
 
    ;; swiper
    (swiper-line-face :background bg-alt2)
@@ -184,7 +170,7 @@ background contrast. All other values default to \"medium\"."
    (ivy-posframe-border :background base1)
 
    ;; neotree
-   (neo-root-dir-face   :foreground aqua)
+   (neo-root-dir-face   :foreground cyan)
    (doom-neotree-dir-face :foreground cyan)
    (neo-dir-link-face   :foreground cyan)
    (doom-neotree-file-face :foreground fg)
@@ -195,36 +181,36 @@ background contrast. All other values default to \"medium\"."
    ;; dired
    (dired-directory :foreground cyan)
    (dired-marked :foreground yellow)
-   (dired-symlink :foreground aqua)
-   (dired-header :foreground aqua)
+   (dired-symlink :foreground cyan)
+   (dired-header :foreground cyan)
 
    ;;;;;;;; Brackets ;;;;;;;;
    ;; Rainbow-delimiters
    (rainbow-delimiters-depth-1-face :foreground red)
    (rainbow-delimiters-depth-2-face :foreground yellow)
-   (rainbow-delimiters-depth-3-face :foreground aqua)
+   (rainbow-delimiters-depth-3-face :foreground cyan)
    (rainbow-delimiters-depth-4-face :foreground red)
    (rainbow-delimiters-depth-5-face :foreground yellow)
-   (rainbow-delimiters-depth-6-face :foreground aqua)
+   (rainbow-delimiters-depth-6-face :foreground cyan)
    (rainbow-delimiters-depth-7-face :foreground red)
    ;; Bracket pairing
-   ((show-paren-match &override) :foreground nil :background bg4 :bold t)
+   ((show-paren-match &override) :foreground nil :background base5 :bold t)
    ((show-paren-mismatch &override) :foreground nil :background "red")
 
    ;;;;;;;; which-key ;;;;;;;;
-   (which-func :foreground aqua)
+   (which-func :foreground cyan)
    (which-key-command-description-face :foreground fg)
    (which-key-group-description-face :foreground (doom-lighten fg-alt 0.25))
    (which-key-local-map-description-face :foreground cyan)
 
    ;;;;;;;; Company ;;;;;;;;
-   (company-preview-common :foreground aqua)
-   (company-tooltip-common :foreground aqua)
-   (company-tooltip-common-selection :foreground aqua)
+   (company-preview-common :foreground cyan)
+   (company-tooltip-common :foreground cyan)
+   (company-tooltip-common-selection :foreground cyan)
    (company-tooltip-annotation :foreground cyan)
    (company-tooltip-annotation-selection :foreground cyan)
    (company-scrollbar-bg :background bg-alt)
-   (company-scrollbar-fg :background aqua)
+   (company-scrollbar-fg :background cyan)
    (company-tooltip-selection :background bg-alt2)
    (company-tooltip-mouse :background bg-alt2 :foreground nil)
 
@@ -232,11 +218,11 @@ background contrast. All other values default to \"medium\"."
    (+workspace-tab-selected-face :background dark-green :foreground "white")
 
    ;; Undo tree
-   (undo-tree-visualizer-active-branch-face :foreground aqua)
+   (undo-tree-visualizer-active-branch-face :foreground cyan)
    (undo-tree-visualizer-current-face :foreground yellow)
 
    ;; General UI
-   (button :foreground aqua :underline t :bold t)
+   (button :foreground cyan :underline t :bold t)
 
    ;; ediff
    (ediff-fine-diff-A    :background (doom-blend red bg 0.3) :weight 'bold)
@@ -245,7 +231,7 @@ background contrast. All other values default to \"medium\"."
    ;; flycheck
    (flycheck-error   :underline `(:style wave :color ,red)    :background base3)
    (flycheck-warning :underline `(:style wave :color ,yellow) :background base3)
-   (flycheck-info    :underline `(:style wave :color ,aqua)  :background base3)
+   (flycheck-info    :underline `(:style wave :color ,cyan)  :background base3)
 
    ;; helm
    (helm-swoop-target-line-face :foreground magenta :inverse-video t)
@@ -278,7 +264,7 @@ background contrast. All other values default to \"medium\"."
    (markdown-blockquote-face :inherit 'italic :foreground cyan)
    (markdown-list-face :foreground red)
    (markdown-url-face :foreground red)
-   (markdown-pre-face  :foreground aqua)
+   (markdown-pre-face  :foreground cyan)
    (markdown-link-face :inherit 'bold :foreground cyan)
    ((markdown-code-face &override) :background (doom-lighten base2 0.045))
 
@@ -288,7 +274,7 @@ background contrast. All other values default to \"medium\"."
    ;; org-mode
    ((outline-1 &override) :foreground yellow)
    ((outline-2 &override) :foreground cyan)
-   ((outline-3 &override) :foreground aqua)
+   ((outline-3 &override) :foreground cyan)
    (org-ellipsis :underline nil :foreground orange)
    (org-tag :foreground yellow :bold nil)
    ((org-quote &override) :inherit 'italic :foreground base7 :background org-quote)
@@ -297,8 +283,8 @@ background contrast. All other values default to \"medium\"."
 
    ;; web-mode
    (web-mode-html-tag-bracket-face :foreground blue)
-   (web-mode-html-tag-face         :foreground aqua)
-   (web-mode-html-attr-name-face   :foreground aqua))
+   (web-mode-html-tag-face         :foreground cyan)
+   (web-mode-html-attr-name-face   :foreground cyan))
   ;; --- extra variables --------------------
   ;; ()
   )

--- a/themes/doom-gruvbox-theme.el
+++ b/themes/doom-gruvbox-theme.el
@@ -284,7 +284,9 @@ background contrast. All other values default to \"medium\"."
    ;; web-mode
    (web-mode-html-tag-bracket-face :foreground blue)
    (web-mode-html-tag-face         :foreground cyan)
-   (web-mode-html-attr-name-face   :foreground cyan))
+   (web-mode-html-attr-name-face   :foreground cyan)
+   (web-mode-json-key-face         :foreground green)
+   (web-mode-json-context-face     :foreground cyan))
   ;; --- extra variables --------------------
   ;; ()
   )

--- a/themes/doom-gruvbox-theme.el
+++ b/themes/doom-gruvbox-theme.el
@@ -225,8 +225,8 @@ background contrast. All other values default to \"medium\"."
    (button :foreground cyan :underline t :bold t)
 
    ;; ediff
-   (ediff-fine-diff-A    :background (doom-blend red bg 0.3) :weight 'bold)
-   (ediff-current-diff-A :background (doom-blend red bg 0.1))
+   (ediff-fine-diff-A    :background (doom-blend red bg 0.4) :weight 'bold)
+   (ediff-current-diff-A :background (doom-blend red bg 0.2))
 
    ;; flycheck
    (flycheck-error   :underline `(:style wave :color ,red)    :background base3)

--- a/themes/doom-gruvbox-theme.el
+++ b/themes/doom-gruvbox-theme.el
@@ -20,66 +20,92 @@ determine the exact padding."
   :group 'doom-gruvbox-theme
   :type '(choice integer boolean))
 
+(defcustom doom-gruvbox-dark-variant nil
+  "A choice of \"hard\" or \"soft\" can be used to change the
+background contrast. All other values default to \"medium\"."
+  :group 'doom-gruvbox-theme
+  :type  'string)
+
 ;;
 (def-doom-theme doom-gruvbox
   "Dark theme with pastel 'retro groove' colors."
 
   ;; name        gui       256       16
-  ((bg         '("#282828" "#282828"  nil         ))
-   (bg-alt     '("#323232" "#323232"  nil         ))
-   (accent     '("#504945" "#504945" "brown"      ))
+  ((bg
+    (cond ((equal doom-gruvbox-dark-variant "hard") '("#1d2021" "#1e1e1e" nil))   ; bg0_h
+          ((equal doom-gruvbox-dark-variant "soft") '("#32302f" "#323232" nil))   ; bg0_s
+          (t                                        '("#282828" "#282828" nil)))) ; bg0
+   (bg-alt
+    (cond ((equal doom-gruvbox-dark-variant "hard") '("#282828" "#282828" nil))
+          ((equal doom-gruvbox-dark-variant "soft") '("#403d3d" "#404040" nil))
+          (t                                        '("#32302f" "#323232" nil))))
+   (bg-alt2    '("#504945" "#504945" "brown"      )) ; bg2 (for region, selection etc.)
 
-   (base0      '("#1B2229" "black"   "black"      ))
-   (base1      '("#151617" "#101010" "brightblack"))
-   (base2      '("#1d1f20" "#191919" "brightblack"))
-   (base3      '("#2d2e2e" "#252525" "brightblack"))
-   (base4      '("#4e4e4e" "#454545" "brightblack"))
-   (base5      '("#555556" "#6b6b6b" "brightblack"))
-   (base6      '("#7c6f64" "#7b7b7b" "brightblack"))
-   (base7      '("#cfc0c5" "#c1c1c1" "brightblack"))
-   (base8      '("#ffffff" "#ffffff" "brightwhite"))
-   (fg         '("#ebdbb2" "#dfdfdf" "brightwhite"))
-   (fg-alt     '("#928374" "#dfdfdf" "brightwhite"))
+   (base0      '("#0d1011" "black"   "black"      )) ; (self-defined)
+   (base1      '("#1d2021" "#1d1d1d" "brightblack")) ; bg0_h
+   (base2      '("#282828" "#282828" "brightblack")) ; bg0
+   (base3      '("#3c3836" "#383838" "brightblack")) ; bg1
+   (base4      '("#665c54" "#5c5c5c" "brightblack")) ; bg3
+   (base5      '("#7c6f64" "#6f6f6f" "brightblack")) ; bg4
+   (base6      '("#928374" "#909090" "brightblack")) ; gray
+   (base7      '("#d5c4a1" "#cccccc" "brightblack")) ; fg2
+   (base8      '("#fbf1c7" "#fbfbfb" "brightwhite")) ; fg0
+   (fg         '("#ebdbb2" "#dfdfdf" "brightwhite")) ; fg/fg1
+   (fg-alt     '("#d5c4a1" "#cccccc" "brightwhite")) ; fg2
 
-   (grey       '("#555556" "#515154" "brightblack"))
-   (red        '("#fb4934" "#e74c3c" "red"))
-   (magenta    '("#fb2874" "#fb2874" "magenta"))
-   (violet     '("#d3869b" "#d3869b" "brightmagenta"))
-   (orange     '("#fe8019" "#fd971f" "brightred"))
-   (yellow     '("#fabd2f" "#fabd2f" "yellow"))
-   (dark-green '("#689d6a" "#689d6a" "green"))
-   (green      '("#8ec07c" "#8ec07c" "green"))
-   (teal       green)
-   (olive      '("#b8bb26" "#b8bb26" "green"))
-   (blue       '("#268bd2" "#2686D6" "brightblue"))
-   (dark-blue  '("#727280" "#727280" "blue"))
-   (cyan       '("#83a598" "#83a598" "brightcyan"))
-   (dark-cyan  '("#458588" "#458588" "cyan"))
+   ;; Standardized official colours from gruvbox
+   (grey       '("#928374" "#909090" "brightblack"))   ; gray
+   (red        '("#fb4934" "#e74c3c" "red"))           ; bright-red
+   (magenta    '("#cc241d" "#cc241d" "magenta"))       ; red
+   (violet     '("#d3869b" "#d3869b" "brightmagenta")) ; bright-purple
+   (orange     '("#fe8019" "#fd971f" "orange"))        ; bright-orange
+   (yellow     '("#fabd2f" "#fabd2f" "yellow"))        ; bright-yellow
+   (teal       '("#8ec07c" "#8ec07c" "green"))         ; bright-aqua
+   (green      '("#b8bb26" "#b8bb26" "green"))         ; bright-green
+   (dark-green '("#98971a" "#98971a" "green"))         ; green
+   (blue       '("#83a598" "#83a598" "brightblue"))    ; bright-blue
+   (dark-blue  '("#458588" "#458588" "blue"))          ; blue
+   (cyan       '("#8ec07c" "#8ec07c" "brightcyan"))    ; bright-aqua
+   (dark-cyan  '("#689d6a" "#689d6a" "cyan"))          ; aqua
+
+   ;; Extra
+   (aqua      '("#8ec07c" "#8ec07c" "brightcyan"))  ; bright-aqua
+   (dark-aqua '("#689d6a" "#689d6a" "cyan"))        ; aqua
+   (bg0       '("#282828" "#282828" "brightblack")) ; bg0
+   (bg1       '("#3c3836" "#383838" "brightblack")) ; bg1
+   (bg2       '("#504945" "#494949" "brightblack")) ; bg2
+   (bg3       '("#665c54" "#5c5c5c" "brightblack")) ; bg3
+   (bg4       '("#7c6f64" "#6f6f6f" "brightblack")) ; bg4
+   (fg0       '("#fbf1c7" "#fbfbfb" "brightwhite")) ; fg0
+   (fg1       '("#ebdbb2" "#dfdfdf" "brightwhite")) ; fg/fg1
+   (fg2       '("#d5c4a1" "#cccccc" "brightblack")) ; fg2
+   (fg3       '("#bdae93" "#bdbdbd" "brightblack")) ; fg3
+   (fg4       '("#a89984" "#999999" "brightblack")) ; fg4
 
    ;; face categories
    (highlight      yellow)
    (vertical-bar   grey)
-   (selection      accent)
+   (selection      bg-alt2)
    (builtin        orange)
-   (comments       (if doom-gruvbox-brighter-comments magenta base6))
+   (comments       (if doom-gruvbox-brighter-comments magenta grey))
    (doc-comments   (if doom-gruvbox-brighter-comments (doom-lighten magenta 0.2) (doom-lighten fg-alt 0.25)))
    (constants      violet)
-   (functions      green)
+   (functions      aqua)
    (keywords       red)
-   (methods        green)
+   (methods        aqua)
    (operators      cyan)
    (type           yellow)
-   (strings        olive)
+   (strings        green)
    (variables      cyan)
    (numbers        violet)
-   (region         accent)
+   (region         bg-alt2)
    (error          red)
    (warning        yellow)
    (success        green)
 
-   (vc-modified    accent)
+   (vc-modified    (doom-darken blue 0.15))
    (vc-added       (doom-darken green 0.15))
-   (vc-deleted     red)
+   (vc-deleted     (doom-darken red 0.15))
 
    ;; custom categories
    (-modeline-pad
@@ -95,17 +121,17 @@ determine the exact padding."
    ;;;;;;;; Editor ;;;;;;;;
    (cursor :background "white")
    (hl-line :background bg-alt)
-   ((line-number-current-line &override) :background grey :foreground "white" :bold t)
-   ((line-number &override) :foreground grey)
+   ((line-number &override) :foreground bg4)
+   ((line-number-current-line &override) :background bg-alt2 :foreground fg :bold t)
 
    ;; Vimish-fold
-   ((vimish-fold-overlay &override) :inherit 'font-lock-comment-face :background accent :weight 'light)
+   ((vimish-fold-overlay &override) :inherit 'font-lock-comment-face :background bg-alt2 :weight 'light)
    ((vimish-fold-mouse-face &override) :foreground "white" :background yellow :weight 'light)
    ((vimish-fold-fringe &override) :foreground magenta :background magenta)
 
    ;;;;;;;; Doom-modeline ;;;;;;;;
    (mode-line
-    :background accent :foreground (doom-lighten fg-alt 0.25)
+    :background bg-alt2 :foreground (doom-lighten fg-alt 0.25)
     :box (if -modeline-pad `(:line-width ,-modeline-pad :color base3)))
 
    (mode-line-inactive
@@ -127,35 +153,38 @@ determine the exact padding."
 
    ;;;;;;;; Search ;;;;;;;;
    ;; /find
-   (isearch :foreground base0 :background yellow)
-   (evil-search-highlight-persist-highlight-face :background orange)
+   (isearch :foreground base0 :background orange)
+   (evil-search-highlight-persist-highlight-face :background yellow)
    (lazy-highlight :background yellow :foreground base0 :distant-foreground base0 :bold bold)
-   (evil-ex-substitute-replacement :foreground yellow :inherit 'evil-ex-substitute-matches)
+   (evil-ex-substitute-replacement :foreground aqua :inherit 'evil-ex-substitute-matches)
 
    ;; evil-snipe
    (evil-snipe-first-match-face :foreground "white" :background yellow)
    (evil-snipe-matches-face     :foreground yellow :bold t :underline t)
 
    ;;;;;;;; Mini-buffers ;;;;;;;;
-   (minibuffer-prompt :foreground green)
-   (solaire-hl-line-face :background accent)
+   (minibuffer-prompt :foreground aqua)
+   (solaire-hl-line-face :background bg-alt2)
 
    ;; ivy
-   (ivy-current-match :background accent)
+   (ivy-current-match :background bg-alt2)
    (ivy-subdir :background nil :foreground cyan)
    (ivy-action :background nil :foreground cyan)
    (ivy-grep-line-number :background nil :foreground cyan)
    (ivy-minibuffer-match-face-1 :background nil :foreground yellow)
    (ivy-minibuffer-match-face-2 :background nil :foreground yellow)
-   (ivy-minibuffer-match-highlight :foreground olive)
-   (counsel-key-binding :foreground green)
+   (ivy-minibuffer-match-highlight :foreground aqua)
+   (counsel-key-binding :foreground aqua)
+
+   ;; swiper
+   (swiper-line-face :background bg-alt2)
 
    ;; ivy-posframe
    (ivy-posframe :background bg-alt)
    (ivy-posframe-border :background base1)
 
    ;; neotree
-   (neo-root-dir-face   :foreground green )
+   (neo-root-dir-face   :foreground aqua)
    (doom-neotree-dir-face :foreground cyan)
    (neo-dir-link-face   :foreground cyan)
    (doom-neotree-file-face :foreground fg)
@@ -166,52 +195,48 @@ determine the exact padding."
    ;; dired
    (dired-directory :foreground cyan)
    (dired-marked :foreground yellow)
-   (dired-symlink :foreground green)
-
-   ;; term
-   (term-color-blue :background cyan :foreground cyan)
-   (term-color-cyan :background green :foreground green)
-   (term-color-green :background olive :foreground olive)
+   (dired-symlink :foreground aqua)
+   (dired-header :foreground aqua)
 
    ;;;;;;;; Brackets ;;;;;;;;
    ;; Rainbow-delimiters
    (rainbow-delimiters-depth-1-face :foreground red)
    (rainbow-delimiters-depth-2-face :foreground yellow)
-   (rainbow-delimiters-depth-3-face :foreground green)
+   (rainbow-delimiters-depth-3-face :foreground aqua)
    (rainbow-delimiters-depth-4-face :foreground red)
    (rainbow-delimiters-depth-5-face :foreground yellow)
-   (rainbow-delimiters-depth-6-face :foreground green)
+   (rainbow-delimiters-depth-6-face :foreground aqua)
    (rainbow-delimiters-depth-7-face :foreground red)
    ;; Bracket pairing
-   ((show-paren-match &override) :foreground nil :background fg-alt :bold t)
+   ((show-paren-match &override) :foreground nil :background bg4 :bold t)
    ((show-paren-mismatch &override) :foreground nil :background "red")
 
    ;;;;;;;; which-key ;;;;;;;;
-   (which-func :foreground green)
+   (which-func :foreground aqua)
    (which-key-command-description-face :foreground fg)
    (which-key-group-description-face :foreground (doom-lighten fg-alt 0.25))
    (which-key-local-map-description-face :foreground cyan)
 
    ;;;;;;;; Company ;;;;;;;;
-   (company-preview-common :foreground green)
-   (company-tooltip-common :foreground green)
-   (company-tooltip-common-selection :foreground green)
+   (company-preview-common :foreground aqua)
+   (company-tooltip-common :foreground aqua)
+   (company-tooltip-common-selection :foreground aqua)
    (company-tooltip-annotation :foreground cyan)
    (company-tooltip-annotation-selection :foreground cyan)
-   (company-scrollbar-bg :background fg)
-   (company-scrollbar-fg :background green)
-   (company-tooltip-selection :background accent)
-   (company-tooltip-mouse :background accent :foreground nil)
+   (company-scrollbar-bg :background bg-alt)
+   (company-scrollbar-fg :background aqua)
+   (company-tooltip-selection :background bg-alt2)
+   (company-tooltip-mouse :background bg-alt2 :foreground nil)
 
    ;;;;;;;; Misc ;;;;;;;;
    (+workspace-tab-selected-face :background dark-green :foreground "white")
 
    ;; Undo tree
-   (undo-tree-visualizer-active-branch-face :foreground green)
+   (undo-tree-visualizer-active-branch-face :foreground aqua)
    (undo-tree-visualizer-current-face :foreground yellow)
 
    ;; General UI
-   (button :foreground green :underline t :bold t)
+   (button :foreground aqua :underline t :bold t)
 
    ;; ediff
    (ediff-fine-diff-A    :background (doom-blend red bg 0.3) :weight 'bold)
@@ -220,7 +245,7 @@ determine the exact padding."
    ;; flycheck
    (flycheck-error   :underline `(:style wave :color ,red)    :background base3)
    (flycheck-warning :underline `(:style wave :color ,yellow) :background base3)
-   (flycheck-info    :underline `(:style wave :color ,green)  :background base3)
+   (flycheck-info    :underline `(:style wave :color ,aqua)  :background base3)
 
    ;; helm
    (helm-swoop-target-line-face :foreground magenta :inverse-video t)
@@ -229,7 +254,7 @@ determine the exact padding."
    (magit-section-heading             :foreground yellow :weight 'bold)
    (magit-branch-current              :underline cyan :inherit 'magit-branch-local)
    (magit-diff-hunk-heading           :background base3 :foreground fg-alt)
-   (magit-diff-hunk-heading-highlight :background accent :foreground fg)
+   (magit-diff-hunk-heading-highlight :background bg-alt2 :foreground fg)
    (magit-diff-context                :foreground bg-alt :foreground fg-alt)
 
 
@@ -247,7 +272,7 @@ determine the exact padding."
    (markdown-blockquote-face :inherit 'italic :foreground cyan)
    (markdown-list-face :foreground red)
    (markdown-url-face :foreground red)
-   (markdown-pre-face  :foreground green)
+   (markdown-pre-face  :foreground aqua)
    (markdown-link-face :inherit 'bold :foreground cyan)
    ((markdown-code-face &override) :background (doom-lighten base2 0.045))
 
@@ -257,13 +282,17 @@ determine the exact padding."
    ;; org-mode
    ((outline-1 &override) :foreground yellow)
    ((outline-2 &override) :foreground cyan)
-   ((outline-3 &override) :foreground green)
+   ((outline-3 &override) :foreground aqua)
    (org-ellipsis :underline nil :foreground orange)
    (org-tag :foreground yellow :bold nil)
    ((org-quote &override) :inherit 'italic :foreground base7 :background org-quote)
    (org-todo :foreground yellow :bold 'inherit)
-   (org-list-dt :foreground yellow))
+   (org-list-dt :foreground yellow)
 
+   ;; web-mode
+   (web-mode-html-tag-bracket-face :foreground blue)
+   (web-mode-html-tag-face         :foreground aqua)
+   (web-mode-html-attr-name-face   :foreground aqua))
   ;; --- extra variables --------------------
   ;; ()
   )


### PR DESCRIPTION
Added contrast options hard/soft for gruvbox dark, fixed documentation typo for gruvbox light, and tweaked a few other minor details (mostly colour improvements and naming refactors.).