### PR TITLE
Add new themes: homage-white and homage-black

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ DOOM Themes is an opinionated UI plugin and pack of themes extracted from my
   - [X] `doom-zenburn`: port of the popular [Zenburn] theme (thanks to [jsoa])
   - [ ] `doom-mono-dark` / `doom-mono-light`: a minimalistic, monochromatic theme
   - [ ] `doom-tron`: based on Tron Legacy from [daylerees' themes][daylerees]
+  - [ ] `doom-homage-white` / `doom-homage-black` : a minimalistic, colorless theme, inspired by [eziam][eziam], [tao][tao] and [jbeans][jbeans] themes.
 
 ## Features
 
@@ -258,3 +259,6 @@ pointers. Additional theme and plugin support requests are welcome too.
 [rouge theme]: https://github.com/josefaidt/rouge-theme 
 [JordanFaust]: https://github.com/JordanFaust
 [Zenburn]: https://github.com/bbatsov/zenburn-emacs
+[eziam]: https://github.com/thblt/eziam-theme-emacs
+[jbeans]: https://github.com/synic/jbeans-emacs
+[tao]: https://github.com/11111000000/tao-theme-emacs

--- a/themes/doom-homage-black-theme.el
+++ b/themes/doom-homage-black-theme.el
@@ -1,0 +1,225 @@
+;;; doom-homage-black-theme.el --- pitch-black theme version of homage-white -*- no-byte-compile: t; -*-
+;;;
+;;; Commentary:
+;;;
+;;; Theme is (manually) inverted homage-white theme with a focus of having
+;;; pitch-black backgrounds. I'm also incorporated a several ideas from jbeans
+;;; theme (synic/jbeans-emacs).
+
+(require 'doom-themes)
+
+;;
+(defgroup doom-homage-black-theme nil
+  "Options for doom-themes"
+  :group 'doom-themes)
+
+(defcustom doom-homage-black-padded-modeline doom-themes-padded-modeline
+  "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
+determine the exact padding."
+  :group 'doom-homage-black-theme
+  :type '(choice integer boolean))
+
+;;
+(def-doom-theme doom-homage-black
+  "A light theme inspired by Atom One"
+
+  ;; name        default   256       16
+  ((bg         '("#000000" nil       nil            ))
+   (bg-alt     '("#000000" nil       nil            ))
+   (base0      '("#1B2229" "black"   "black"        ))
+   (base1      '("#1c1f24" "#1e1e1e" "brightblack"  ))
+   (base2      '("#202328" "#2e2e2e" "brightblack"  ))
+   (base3      '("#23272e" "#262626" "brightblack"  ))
+   (base4      '("#3f444a" "#3f3f3f" "brightblack"  ))
+   (base5      '("#5B6268" "#525252" "brightblack"  ))
+   (base6      '("#73797e" "#6b6b6b" "brightblack"  ))
+   (base7      '("#9ca0a4" "#979797" "brightblack"  ))
+   (base8      '("#DFDFDF" "#dfdfdf" "white"        ))
+   (fg         '("#bbc2cf" "#bfbfbf" "brightwhite"  ))
+   (fg-alt     '("#5B6268" "#2d2d2d" "white"        ))
+
+   (grey       base8)
+   (red        '("#ff6c6b" "#ff6655" "red"          ))
+   (orange     '("#b4916d" "#b4916d" "brightred"    ))
+   (green      '("#98be65" "#99bb66" "green"        ))
+   (teal       '("#4db5bd" "#44b9b1" "brightgreen"  ))
+   (yellow     '("#ECBE7B" "#ECBE7B" "yellow"       ))
+   (blue       '("#0170bf" "#0170bf" "brightblue"   ))
+   (dark-blue  '("#003c64" "#0170bf" "blue"         ))
+   (magenta    '("#c678dd" "#c678dd" "brightmagenta"))
+   (violet     '("#a9a1e1" "#a9a1e1" "magenta"      ))
+   (cyan       '("#46D9FF" "#46D9FF" "brightcyan"   ))
+   (dark-cyan  '("#5699AF" "#5699AF" "cyan"         ))
+
+   ;; face categories -- required for all themes
+   (highlight      blue)
+   (vertical-bar   (doom-darken base2 0.1))
+   (selection      dark-blue)
+   (builtin        fg)
+   (comments       green)
+   (doc-comments   (doom-darken comments 0.15))
+   (constants      fg)
+   (functions      blue)
+   (keywords       fg)
+   (methods        fg)
+   (operators      fg)
+   (type           fg)
+   (strings        orange)
+   (variables      fg)
+   (numbers        orange)
+   (region         `(,(doom-darken (car dark-blue) 0.1) ,@(doom-darken (cdr base0) 0.3)))
+   (error          red)
+   (warning        yellow)
+   (success        green)
+   (vc-modified    orange)
+   (vc-added       green)
+   (vc-deleted     red)
+
+   ;; custom categories
+   (-modeline-bright t)
+   (-modeline-pad
+    (when doom-homage-black-padded-modeline
+      (if (integerp doom-homage-black-padded-modeline) doom-homage-black-padded-modeline 4)))
+
+   (modeline-fg     nil)
+   (modeline-fg-alt (doom-blend violet base4 (if -modeline-bright 0.5 0.2)))
+
+   (modeline-bg
+    (if -modeline-bright
+        (doom-darken base2 0.05)
+      base1))
+   (modeline-bg-l
+    (if -modeline-bright
+        (doom-darken base2 0.1)
+      base2))
+   (modeline-bg-inactive (doom-darken bg 0.1))
+   (modeline-bg-inactive-l `(,(doom-darken (car bg-alt) 0.05) ,@(cdr base1))))
+
+  ;; --- extra faces ------------------------
+  ((centaur-tabs-unselected :background bg-alt :foreground base4)
+   (font-lock-comment-face
+    :foreground comments)
+   (font-lock-doc-face
+    :inherit 'font-lock-comment-face
+    :foreground doc-comments
+    :slant 'italic)
+
+   ((secondary-selection &override) :background grey :foreground bg :extend t)
+
+   ((line-number &override) :foreground (doom-lighten base4 0.15))
+   ((line-number-current-line &override) :foreground base8)
+
+   ;; Apply bold value for different things
+   (font-lock-builtin-face       :inherit 'bold :foreground base8)
+   (font-lock-function-name-face :inherit 'bold :foreground base8)
+   (font-lock-keyword-face       :inherit 'bold :foreground base8)
+   (font-lock-type-face          :inherit 'bold :foreground base8)
+
+   (doom-modeline-bar :background (if -modeline-bright modeline-bg highlight))
+
+   (mode-line
+    :background modeline-bg :foreground modeline-fg
+    :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg)))
+   (mode-line-inactive
+    :background modeline-bg-inactive :foreground modeline-fg-alt
+    :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg-inactive)))
+   (mode-line-emphasis
+    :foreground (if -modeline-bright base8 highlight))
+
+   (solaire-mode-line-face
+    :inherit 'mode-line
+    :background modeline-bg-l
+    :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg-l)))
+   (solaire-mode-line-inactive-face
+    :inherit 'mode-line-inactive
+    :background modeline-bg-inactive-l
+    :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg-inactive-l)))
+
+   ;; magit
+   ((magit-diff-hunk-heading           &override) :foreground fg    :background bg-alt :bold bold)
+   ((magit-diff-hunk-heading-highlight &override) :foreground base8 :background bg-alt :bold bold)
+   (magit-blame-heading     :foreground orange :background bg-alt)
+   (magit-diff-removed :foreground (doom-darken red 0.2) :background (doom-blend red bg 0.1))
+   (magit-diff-removed-highlight :foreground red :background (doom-blend red bg 0.2) :bold bold)
+
+   ;; --- major-mode faces -------------------
+   ;; css-mode / scss-mode
+   (css-proprietary-property :foreground orange)
+   (css-property             :foreground green)
+   (css-selector             :foreground blue)
+
+   ;; markdown-mode
+   (markdown-markup-face     :foreground base5)
+   (markdown-header-face     :inherit 'bold :foreground red)
+   ((markdown-code-face &override)       :background base1)
+   (mmm-default-submode-face :background base1)
+
+   ;; org-mode
+   ((outline-1 &override) :foreground base8 :inherit 'bold)
+   ((outline-2 &override) :foreground base8 :inherit 'bold)
+   ((outline-3 &override) :foreground base8 :inherit 'bold)
+   ((outline-4 &override) :foreground base8 :inherit 'bold)
+   ((outline-5 &override) :foreground base8 :inherit 'bold)
+   ((outline-6 &override) :foreground base8 :inherit 'bold)
+   ((outline-7 &override) :foreground base8 :inherit 'bold)
+   ((outline-8 &override) :foreground base8 :inherit 'bold)
+
+   ((org-tag &override)   :foreground fg :background base1
+    :box `(:line-width -1 :color ,base5 :style 'released-button))
+   ((org-date &override)  :foreground fg :background base1
+    :box `(:line-width -1 :color ,base5  :style 'released-button))
+   ((org-special-keyword &override)  :foreground base5)
+   ((org-drawer          &override)  :foreground base5)
+
+   ((org-document-title &override) :height 2.0)
+   ((org-block &override) :background base1)
+   ((org-block-begin-line &override) :foreground fg :slant 'italic)
+   (org-ellipsis :underline nil :box nil :background bg-alt :foreground fg :inherit 'bold)
+   ((org-quote &override) :background base1)
+   ((org-table &override) :foreground fg)
+
+   ;; Deadlines
+   (org-upcoming-deadline         :foreground base8)
+   (org-upcoming-distant-deadline :foreground fg)
+
+   ;; Scheduled things
+   (org-scheduled            :foreground base8)
+   (org-scheduled-today      :foreground base8)
+   (org-scheduled-previously :foreground fg)
+
+   ;; Indent guides character face
+   (highlight-indent-guides-character-face :foreground base3)
+
+   ;; helm
+   (helm-candidate-number :background blue :foreground bg)
+
+   ;; web-mode
+   (web-mode-current-element-highlight-face :background dark-blue :foreground bg)
+
+   ;; wgrep
+   (wgrep-face :background base1)
+
+   ;; ediff
+   (ediff-current-diff-A        :foreground red   :background (doom-lighten red 0.8))
+   (ediff-current-diff-B        :foreground green :background (doom-lighten green 0.8))
+   (ediff-current-diff-C        :foreground blue  :background (doom-lighten blue 0.8))
+   (ediff-current-diff-Ancestor :foreground teal  :background (doom-lighten teal 0.8))
+
+   ;; tooltip
+   (tooltip :background base1 :foreground fg)
+
+   ;; posframe
+   (ivy-posframe               :background base0)
+
+   ;; lsp
+   (lsp-ui-doc-background      :background base0)
+   (lsp-face-highlight-read    :background (doom-blend red bg 0.3))
+   (lsp-face-highlight-textual :inherit 'lsp-face-highlight-read)
+   (lsp-face-highlight-write   :inherit 'lsp-face-highlight-read)
+   )
+
+  ;; --- extra variables ---------------------
+  ()
+  )
+
+;;; doom-homage-black-theme.el ends here

--- a/themes/doom-homage-black-theme.el
+++ b/themes/doom-homage-black-theme.el
@@ -220,6 +220,9 @@ determine the exact padding."
    (lsp-face-highlight-read    :background (doom-blend red bg 0.3))
    (lsp-face-highlight-textual :inherit 'lsp-face-highlight-read)
    (lsp-face-highlight-write   :inherit 'lsp-face-highlight-read)
+
+   ;; mu4e
+   (mu4e-highlight-face :background bg :inherit 'bold)
    )
 
   ;; --- extra variables ---------------------

--- a/themes/doom-homage-black-theme.el
+++ b/themes/doom-homage-black-theme.el
@@ -183,9 +183,9 @@ determine the exact padding."
    (org-upcoming-distant-deadline :foreground fg)
 
    ;; Scheduled things
-   (org-scheduled            :foreground base8)
-   (org-scheduled-today      :foreground base8)
-   (org-scheduled-previously :foreground fg)
+   (org-scheduled            :foreground fg)
+   (org-scheduled-today      :foreground fg)
+   (org-scheduled-previously :foreground base8)
 
    ;; Indent guides character face
    (highlight-indent-guides-character-face :foreground base3)

--- a/themes/doom-homage-black-theme.el
+++ b/themes/doom-homage-black-theme.el
@@ -19,11 +19,6 @@ determine the exact padding."
   :group 'doom-homage-black-theme
   :type '(choice integer boolean))
 
-(defcustom doom-homage-black-large-org-headlines nil
-  "If non-nil, make first three org headline faces to be large."
-  :group 'doom-homage-white-theme
-  :type 'boolean)
-
 ;;
 (def-doom-theme doom-homage-black
   "A light theme inspired by Atom One"
@@ -162,46 +157,42 @@ determine the exact padding."
    ((markdown-code-face &override)       :background base1)
    (mmm-default-submode-face :background base1)
 
-   ;; org-mode
-   ((outline-1 &override) :foreground fg :inherit 'bold
-    :height (if doom-homage-black-large-org-headlines 1.8 1.0))
-   ((outline-2 &override) :foreground fg :inherit 'bold
-    :height (if doom-homage-black-large-org-headlines 1.4 1.0))
-   ((outline-3 &override) :foreground fg :inherit 'bold
-    :height (if doom-homage-black-large-org-headlines 1.2 1.0))
-   ((outline-4 &override) :foreground base8 :inherit 'bold)
-   ((outline-5 &override) :foreground base8 :inherit 'bold)
-   ((outline-6 &override) :foreground base8 :inherit 'bold)
-   ((outline-7 &override) :foreground base8 :inherit 'bold)
-   ((outline-8 &override) :foreground base8 :inherit 'bold)
-
-   ((org-todo &override)  :foreground red   :bold 'inherit)
-   ((org-done &override)  :foreground green :bold 'inherit)
+   ;; org-mode: make outline just the same colour as normal text
+   ((outline-1 &override) :foreground fg)
+   ((outline-2 &override) :foreground fg)
+   ((outline-3 &override) :foreground fg)
+   ((outline-4 &override) :foreground fg)
+   ((outline-5 &override) :foreground fg)
+   ((outline-6 &override) :foreground fg)
+   ((outline-7 &override) :foreground fg)
+   ((outline-8 &override) :foreground fg)
+   ;; org-mode: make unfinished cookie and todo keywords to be very bright to
+   ;; grab attention
+   ((org-todo &override) :foreground red)
+   ;; org-mode: make tags and dates to have pretty box around them
    ((org-tag &override)   :foreground fg :background base1
     :box `(:line-width -1 :color ,base5 :style 'released-button))
    ((org-date &override)  :foreground fg :background base1
     :box `(:line-width -1 :color ,base5  :style 'released-button))
-   ((org-special-keyword &override)  :foreground base5)
-   ((org-drawer          &override)  :foreground base5)
-
-   ((org-document-title &override) :height 2.0)
+   ;; org-mode: Make drawers and special keywords (like scheduled) to be very bleak
+   ((org-special-keyword &override)  :foreground grey)
+   ((org-drawer          &override)  :foreground grey)
+   ;; org-mode: Make ellipsis as bleak as possible and reset any underline and boxing
+   ;; properties
+   (org-ellipsis :underline nil :box nil :foreground fg)
+   ;; org-mode: Make blocks have a slightly different background
    ((org-block &override) :background base1)
    ((org-block-begin-line &override) :foreground fg :slant 'italic)
-   (org-ellipsis :underline nil :box nil :background bg-alt :foreground fg :inherit 'bold)
    ((org-quote &override) :background base1)
    ((org-table &override) :foreground fg)
 
-   ;; Deadlines
+   ;; org-agendamode: make "unimportant" things like distant deadlines and
+   ;; things scheduled for today to be bleak.
    (org-upcoming-deadline         :foreground base8)
    (org-upcoming-distant-deadline :foreground fg)
-
-   ;; Scheduled things
-   (org-scheduled            :foreground fg)
-   (org-scheduled-today      :foreground fg)
-   (org-scheduled-previously :foreground base8)
-
-   ;; Indent guides character face
-   (highlight-indent-guides-character-face :foreground base3)
+   (org-scheduled                 :foreground fg)
+   (org-scheduled-today           :foreground fg)
+   (org-scheduled-previously      :foreground base8)
 
    ;; helm
    (helm-candidate-number :background blue :foreground bg)

--- a/themes/doom-homage-black-theme.el
+++ b/themes/doom-homage-black-theme.el
@@ -19,6 +19,11 @@ determine the exact padding."
   :group 'doom-homage-black-theme
   :type '(choice integer boolean))
 
+(defcustom doom-homage-black-large-org-headlines nil
+  "If non-nil, make first three org headline faces to be large."
+  :group 'doom-homage-white-theme
+  :type 'boolean)
+
 ;;
 (def-doom-theme doom-homage-black
   "A light theme inspired by Atom One"
@@ -155,9 +160,12 @@ determine the exact padding."
    (mmm-default-submode-face :background base1)
 
    ;; org-mode
-   ((outline-1 &override) :foreground base8 :inherit 'bold)
-   ((outline-2 &override) :foreground base8 :inherit 'bold)
-   ((outline-3 &override) :foreground base8 :inherit 'bold)
+   ((outline-1 &override) :foreground fg :inherit 'bold
+    :height (if doom-homage-black-large-org-headlines 1.8 1.0))
+   ((outline-2 &override) :foreground fg :inherit 'bold
+    :height (if doom-homage-black-large-org-headlines 1.4 1.0))
+   ((outline-3 &override) :foreground fg :inherit 'bold
+    :height (if doom-homage-black-large-org-headlines 1.2 1.0))
    ((outline-4 &override) :foreground base8 :inherit 'bold)
    ((outline-5 &override) :foreground base8 :inherit 'bold)
    ((outline-6 &override) :foreground base8 :inherit 'bold)

--- a/themes/doom-homage-black-theme.el
+++ b/themes/doom-homage-black-theme.el
@@ -43,7 +43,7 @@ determine the exact padding."
    (fg         '("#bbc2cf" "#bfbfbf" "brightwhite"  ))
    (fg-alt     '("#5B6268" "#2d2d2d" "white"        ))
 
-   (grey       base8)
+   (grey       base5)
    (red        '("#ff6c6b" "#ff6655" "red"          ))
    (orange     '("#b4916d" "#b4916d" "brightred"    ))
    (green      '("#98be65" "#99bb66" "green"        ))
@@ -109,10 +109,13 @@ determine the exact padding."
     :foreground doc-comments
     :slant 'italic)
 
-   ((secondary-selection &override) :background grey :foreground bg :extend t)
-
    ((line-number &override) :foreground (doom-lighten base4 0.15))
    ((line-number-current-line &override) :foreground base8)
+
+   ;; Change swiper colours, background and foreground are too close
+   ((swiper-match-face-1 &override) :background fg        :foreground bg)
+   ((swiper-line-face    &override) :background dark-blue :foreground fg)
+   ((ivy-minibuffer-match-face-1 &override) :foreground (doom-lighten grey 0.70))
 
    ;; Apply bold value for different things
    (font-lock-builtin-face       :inherit 'bold :foreground base8)

--- a/themes/doom-homage-black-theme.el
+++ b/themes/doom-homage-black-theme.el
@@ -104,6 +104,9 @@ determine the exact padding."
     :foreground doc-comments
     :slant 'italic)
 
+   ;; Override hl-line colour as bg-alt is too dark
+   ((hl-line &override) :background (doom-darken highlight 0.30))
+
    ((line-number &override) :foreground (doom-lighten base4 0.15))
    ((line-number-current-line &override) :foreground base8)
 

--- a/themes/doom-homage-black-theme.el
+++ b/themes/doom-homage-black-theme.el
@@ -107,6 +107,9 @@ determine the exact padding."
    ((line-number &override) :foreground (doom-lighten base4 0.15))
    ((line-number-current-line &override) :foreground base8)
 
+   ;; Override secondary selection
+   ((secondary-selection &override) :background base0)
+
    ;; Change swiper colours, background and foreground are too close
    ((swiper-match-face-1 &override) :background fg        :foreground bg)
    ((swiper-line-face    &override) :background dark-blue :foreground fg)

--- a/themes/doom-homage-black-theme.el
+++ b/themes/doom-homage-black-theme.el
@@ -164,6 +164,8 @@ determine the exact padding."
    ((outline-7 &override) :foreground base8 :inherit 'bold)
    ((outline-8 &override) :foreground base8 :inherit 'bold)
 
+   ((org-todo &override)  :foreground red   :bold 'inherit)
+   ((org-done &override)  :foreground green :bold 'inherit)
    ((org-tag &override)   :foreground fg :background base1
     :box `(:line-width -1 :color ,base5 :style 'released-button))
    ((org-date &override)  :foreground fg :background base1

--- a/themes/doom-homage-black-theme.el
+++ b/themes/doom-homage-black-theme.el
@@ -105,7 +105,7 @@ determine the exact padding."
     :slant 'italic)
 
    ;; Override hl-line colour as bg-alt is too dark
-   ((hl-line &override) :background (doom-darken highlight 0.30))
+   ((hl-line &override) :background (doom-darken highlight 0.75))
 
    ((line-number &override) :foreground (doom-lighten base4 0.15))
    ((line-number-current-line &override) :foreground base8)

--- a/themes/doom-homage-black-theme.el
+++ b/themes/doom-homage-black-theme.el
@@ -179,7 +179,7 @@ determine the exact padding."
    ((org-drawer          &override)  :foreground grey)
    ;; org-mode: Make ellipsis as bleak as possible and reset any underline and boxing
    ;; properties
-   (org-ellipsis :underline nil :box nil :foreground fg)
+   (org-ellipsis :underline nil :box nil :foreground fg :background bg)
    ;; org-mode: Make blocks have a slightly different background
    ((org-block &override) :background base1)
    ((org-block-begin-line &override) :foreground fg :slant 'italic)

--- a/themes/doom-homage-white-theme.el
+++ b/themes/doom-homage-white-theme.el
@@ -165,6 +165,8 @@ determine the exact padding."
    ((outline-7 &override) :foreground fg :inherit 'bold)
    ((outline-8 &override) :foreground fg :inherit 'bold)
 
+   ((org-todo &override)  :foreground red   :bold 'inherit)
+   ((org-done &override)  :foreground green :bold 'inherit)
    ((org-tag &override)   :foreground fg :background yellow-alt
     :box '(:line-width -1 :color "#333333" :style 'released-button))
    ((org-date &override)  :foreground fg :background base1

--- a/themes/doom-homage-white-theme.el
+++ b/themes/doom-homage-white-theme.el
@@ -1,0 +1,226 @@
+;;; doom-homage-white-theme.el --- minimal white theme inspired by editors from 2000s -*- no-byte-compile: t; -*-
+;;;
+;;; Commentary:
+;;;
+;;; Theme is using palette inspired by various editors from 2000s, with a lot of
+;;; inspiration from eziam theme (thblt/eziam-theme-emacs) and tao themes
+;;; (11111000000/tao-theme-emacs).
+
+(require 'doom-themes)
+
+;;
+(defgroup doom-homage-white-theme nil
+  "Options for doom-themes"
+  :group 'doom-themes)
+
+(defcustom doom-homage-white-padded-modeline doom-themes-padded-modeline
+  "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
+determine the exact padding."
+  :group 'doom-homage-white-theme
+  :type '(choice integer boolean))
+
+;;
+(def-doom-theme doom-homage-white
+  "A light theme inspired by Atom One"
+
+  ;; name        default   256       16
+  ((bg         '("#fafafa" nil       nil            ))
+   (bg-alt     '("#f0f0f0" nil       nil            ))
+   (base0      '("#f0f0f0" "#f0f0f0" "white"        ))
+   (base1      '("#e7e7e7" "#e7e7e7" "brightblack"  ))
+   (base2      '("#dfdfdf" "#dfdfdf" "brightblack"  ))
+   (base3      '("#c6c7c7" "#c6c7c7" "brightblack"  ))
+   (base4      '("#9ca0a4" "#9ca0a4" "brightblack"  ))
+   (base5      '("#383a42" "#424242" "brightblack"  ))
+   (base6      '("#202328" "#2e2e2e" "brightblack"  ))
+   (base7      '("#1c1f24" "#1e1e1e" "brightblack"  ))
+   (base8      '("#1b2229" "black"   "black"        ))
+   (fg         '("#383a42" "#424242" "black"        ))
+   (fg-alt     '("#c6c7c7" "#c7c7c7" "brightblack"  ))
+
+   (grey       base8)
+   (red        '("#e45649" "#e45649" "red"          ))
+   (orange     '("#8a3b3c" "#dd8844" "brightred"    ))
+   (green      '("#556b2f" "#556b2f" "green"        ))
+   (teal       '("#4db5bd" "#44b9b1" "brightgreen"  ))
+   (yellow     '("#986801" "#986801" "yellow"       ))
+   (yellow-alt '("#fafadd" "#fafadd" "yellow"       ))
+   (blue       '("#014980" "#014980" "brightblue"   ))
+   (dark-blue  '("#030f64" "#030f64" "blue"         ))
+   (magenta    '("#a626a4" "#a626a4" "magenta"      ))
+   (violet     '("#b751b6" "#b751b6" "brightmagenta"))
+   (cyan       '("#0184bc" "#0184bc" "brightcyan"   ))
+   (dark-cyan  '("#005478" "#005478" "cyan"         ))
+
+   ;; face categories -- required for all themes
+   (highlight      blue)
+   (vertical-bar   (doom-darken base2 0.1))
+   (selection      grey)
+   (builtin        fg)
+   (comments       green)
+   (doc-comments   (doom-darken comments 0.15))
+   (constants      fg)
+   (functions      blue)
+   (keywords       fg)
+   (methods        fg)
+   (operators      fg)
+   (type           fg)
+   (strings        orange)
+   (variables      fg)
+   (numbers        orange)
+   (region         `(,(doom-darken (car bg-alt) 0.1) ,@(doom-darken (cdr base0) 0.3)))
+   (error          red)
+   (warning        yellow)
+   (success        green)
+   (vc-modified    orange)
+   (vc-added       green)
+   (vc-deleted     red)
+
+   ;; custom categories
+   (-modeline-bright t)
+   (-modeline-pad
+    (when doom-homage-white-padded-modeline
+      (if (integerp doom-homage-white-padded-modeline) doom-homage-white-padded-modeline 4)))
+
+   (modeline-fg     nil)
+   (modeline-fg-alt (doom-blend violet base4 (if -modeline-bright 0.5 0.2)))
+
+   (modeline-bg
+    (if -modeline-bright
+        (doom-darken base2 0.05)
+      base1))
+   (modeline-bg-l
+    (if -modeline-bright
+        (doom-darken base2 0.1)
+      base2))
+   (modeline-bg-inactive (doom-darken bg 0.1))
+   (modeline-bg-inactive-l `(,(doom-darken (car bg-alt) 0.05) ,@(cdr base1))))
+
+  ;; --- extra faces ------------------------
+  ((centaur-tabs-unselected :background bg-alt :foreground base4)
+   (font-lock-comment-face
+    :foreground comments)
+   (font-lock-doc-face
+    :inherit 'font-lock-comment-face
+    :foreground doc-comments
+    :slant 'italic)
+
+   ((secondary-selection &override) :background grey :foreground bg :extend t)
+
+   ((line-number &override) :foreground (doom-lighten base4 0.15))
+   ((line-number-current-line &override) :foreground base8)
+
+   ;; Apply bold value for different things
+   (font-lock-builtin-face       :inherit 'bold)
+   (font-lock-function-name-face :inherit 'bold)
+   (font-lock-keyword-face       :inherit 'bold)
+   (font-lock-type-face          :inherit 'bold)
+
+   (doom-modeline-bar :background (if -modeline-bright modeline-bg highlight))
+
+   (mode-line
+    :background modeline-bg :foreground modeline-fg
+    :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg)))
+   (mode-line-inactive
+    :background modeline-bg-inactive :foreground modeline-fg-alt
+    :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg-inactive)))
+   (mode-line-emphasis
+    :foreground (if -modeline-bright base8 highlight))
+
+   (solaire-mode-line-face
+    :inherit 'mode-line
+    :background modeline-bg-l
+    :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg-l)))
+   (solaire-mode-line-inactive-face
+    :inherit 'mode-line-inactive
+    :background modeline-bg-inactive-l
+    :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg-inactive-l)))
+
+   ;; magit
+   ((magit-diff-hunk-heading           &override) :foreground base4 :background bg :bold bold)
+   ((magit-diff-hunk-heading-highlight &override) :foreground fg    :background bg :bold bold)
+   (magit-blame-heading     :foreground orange :background bg-alt)
+   (magit-diff-removed :foreground (doom-darken red 0.2) :background (doom-blend red bg 0.1))
+   (magit-diff-removed-highlight :foreground red :background (doom-blend red bg 0.2) :bold bold)
+
+   ;; --- major-mode faces -------------------
+   ;; css-mode / scss-mode
+   (css-proprietary-property :foreground orange)
+   (css-property             :foreground green)
+   (css-selector             :foreground blue)
+
+   ;; markdown-mode
+   (markdown-markup-face     :foreground base5)
+   (markdown-header-face     :inherit 'bold :foreground red)
+   ((markdown-code-face &override)       :background base1)
+   (mmm-default-submode-face :background base1)
+
+   ;; org-mode
+   ((outline-1 &override) :foreground fg :inherit 'bold)
+   ((outline-2 &override) :foreground fg :inherit 'bold)
+   ((outline-3 &override) :foreground fg :inherit 'bold)
+   ((outline-4 &override) :foreground fg :inherit 'bold)
+   ((outline-5 &override) :foreground fg :inherit 'bold)
+   ((outline-6 &override) :foreground fg :inherit 'bold)
+   ((outline-7 &override) :foreground fg :inherit 'bold)
+   ((outline-8 &override) :foreground fg :inherit 'bold)
+
+   ((org-tag &override)   :foreground fg :background yellow-alt
+    :box '(:line-width -1 :color "#333333" :style 'released-button))
+   ((org-date &override)  :foreground fg :background base1
+    :box '(:line-width -1 :color "#333333" :style 'released-button))
+   ((org-special-keyword &override)  :foreground base5)
+   ((org-drawer          &override)  :foreground base5)
+
+   ((org-document-title &override) :height 2.0)
+   ((org-block &override) :background base1)
+   ((org-block-begin-line &override) :foreground fg :slant 'italic)
+   (org-ellipsis :underline nil :box nil :background bg-alt :foreground fg :inherit 'bold)
+   ((org-quote &override) :background base1)
+   ((org-table &override) :foreground fg)
+
+   ;; Deadlines
+   ((org-upcoming-deadline &override)         :foreground fg)
+   ((org-upcoming-distant-deadline &override) :foreground base5)
+
+   ;; Scheduled things
+   ((org-scheduled &override)            :foreground fg)
+   ((org-scheduled-today &override)      :foreground fg)
+   ((org-scheduled-previously &override) :foreground base5)
+
+   ;; Indent guides character face
+   (highlight-indent-guides-character-face :foreground base2)
+
+   ;; helm
+   (helm-candidate-number :background blue :foreground bg)
+
+   ;; web-mode
+   (web-mode-current-element-highlight-face :background dark-blue :foreground bg)
+
+   ;; wgrep
+   (wgrep-face :background base1)
+
+   ;; ediff
+   (ediff-current-diff-A        :foreground red   :background (doom-lighten red 0.8))
+   (ediff-current-diff-B        :foreground green :background (doom-lighten green 0.8))
+   (ediff-current-diff-C        :foreground blue  :background (doom-lighten blue 0.8))
+   (ediff-current-diff-Ancestor :foreground teal  :background (doom-lighten teal 0.8))
+
+   ;; tooltip
+   (tooltip :background base1 :foreground fg)
+
+   ;; posframe
+   (ivy-posframe               :background base0)
+
+   ;; lsp
+   (lsp-ui-doc-background      :background base0)
+   (lsp-face-highlight-read    :background (doom-blend red bg 0.3))
+   (lsp-face-highlight-textual :inherit 'lsp-face-highlight-read)
+   (lsp-face-highlight-write   :inherit 'lsp-face-highlight-read)
+   )
+
+  ;; --- extra variables ---------------------
+  ()
+  )
+
+;;; doom-homage-white-theme.el ends here

--- a/themes/doom-homage-white-theme.el
+++ b/themes/doom-homage-white-theme.el
@@ -224,6 +224,11 @@ determine the exact padding."
    (lsp-face-highlight-read    :background (doom-blend red bg 0.3))
    (lsp-face-highlight-textual :inherit 'lsp-face-highlight-read)
    (lsp-face-highlight-write   :inherit 'lsp-face-highlight-read)
+
+   ;; mu4e
+   (mu4e-highlight-face         :background bg :inherit 'bold)
+   (mu4e-header-highlight-face :foreground dark-blue :inherit 'bold)
+   (mu4e-unread-face :foreground blue)
    )
 
   ;; --- extra variables ---------------------

--- a/themes/doom-homage-white-theme.el
+++ b/themes/doom-homage-white-theme.el
@@ -180,7 +180,7 @@ determine the exact padding."
    ((org-drawer          &override)  :foreground grey)
    ;; org-mode: Make ellipsis as bleak as possible and reset any underline and boxing
    ;; properties
-   (org-ellipsis :underline nil :box nil :foreground fg)
+   (org-ellipsis :underline nil :box nil :foreground fg :background bg)
    ;; org-mode: Make blocks have a slightly different background
    ((org-block &override) :background base1)
    ((org-block-begin-line &override) :foreground fg :slant 'italic)

--- a/themes/doom-homage-white-theme.el
+++ b/themes/doom-homage-white-theme.el
@@ -19,6 +19,11 @@ determine the exact padding."
   :group 'doom-homage-white-theme
   :type '(choice integer boolean))
 
+(defcustom doom-homage-white-large-org-headlines nil
+  "If non-nil, make first three org headline faces to be large."
+  :group 'doom-homage-white-theme
+  :type 'boolean)
+
 ;;
 (def-doom-theme doom-homage-white
   "A light theme inspired by Atom One"
@@ -156,9 +161,12 @@ determine the exact padding."
    (mmm-default-submode-face :background base1)
 
    ;; org-mode
-   ((outline-1 &override) :foreground fg :inherit 'bold)
-   ((outline-2 &override) :foreground fg :inherit 'bold)
-   ((outline-3 &override) :foreground fg :inherit 'bold)
+   ((outline-1 &override) :foreground fg :inherit 'bold
+    :height (if doom-homage-white-large-org-headlines 1.8 1.0))
+   ((outline-2 &override) :foreground fg :inherit 'bold
+    :height (if doom-homage-white-large-org-headlines 1.4 1.0))
+   ((outline-3 &override) :foreground fg :inherit 'bold
+    :height (if doom-homage-white-large-org-headlines 1.2 1.0))
    ((outline-4 &override) :foreground fg :inherit 'bold)
    ((outline-5 &override) :foreground fg :inherit 'bold)
    ((outline-6 &override) :foreground fg :inherit 'bold)

--- a/themes/doom-homage-white-theme.el
+++ b/themes/doom-homage-white-theme.el
@@ -19,11 +19,6 @@ determine the exact padding."
   :group 'doom-homage-white-theme
   :type '(choice integer boolean))
 
-(defcustom doom-homage-white-large-org-headlines nil
-  "If non-nil, make first three org headline faces to be large."
-  :group 'doom-homage-white-theme
-  :type 'boolean)
-
 ;;
 (def-doom-theme doom-homage-white
   "A light theme inspired by Atom One"
@@ -163,43 +158,42 @@ determine the exact padding."
    ((markdown-code-face &override)       :background base1)
    (mmm-default-submode-face :background base1)
 
-   ;; org-mode
-   ((outline-1 &override) :foreground fg :inherit 'bold
-    :height (if doom-homage-white-large-org-headlines 1.8 1.0))
-   ((outline-2 &override) :foreground fg :inherit 'bold
-    :height (if doom-homage-white-large-org-headlines 1.4 1.0))
-   ((outline-3 &override) :foreground fg :inherit 'bold
-    :height (if doom-homage-white-large-org-headlines 1.2 1.0))
-   ((outline-4 &override) :foreground fg :inherit 'bold)
-   ((outline-5 &override) :foreground fg :inherit 'bold)
-   ((outline-6 &override) :foreground fg :inherit 'bold)
-   ((outline-7 &override) :foreground fg :inherit 'bold)
-   ((outline-8 &override) :foreground fg :inherit 'bold)
-
-   ((org-todo &override)  :foreground red   :bold 'inherit)
-   ((org-done &override)  :foreground green :bold 'inherit)
-   ((org-tag &override)   :foreground fg :background yellow-alt
-    :box '(:line-width -1 :color "#333333" :style 'released-button))
+   ;; org-mode: make outline just the same colour as normal text
+   ((outline-1 &override) :foreground fg)
+   ((outline-2 &override) :foreground fg)
+   ((outline-3 &override) :foreground fg)
+   ((outline-4 &override) :foreground fg)
+   ((outline-5 &override) :foreground fg)
+   ((outline-6 &override) :foreground fg)
+   ((outline-7 &override) :foreground fg)
+   ((outline-8 &override) :foreground fg)
+   ;; org-mode: make unfinished cookie and todo keywords to be very bright to
+   ;; grab attention
+   ((org-todo &override) :foreground red)
+   ;; org-mode: make tags and dates to have pretty box around them
+   ((org-tag &override)   :foreground fg :background base1
+    :box `(:line-width -1 :color ,base5 :style 'released-button))
    ((org-date &override)  :foreground fg :background base1
-    :box '(:line-width -1 :color "#333333" :style 'released-button))
-   ((org-special-keyword &override)  :foreground base5)
-   ((org-drawer          &override)  :foreground base5)
-
-   ((org-document-title &override) :height 2.0)
+    :box `(:line-width -1 :color ,base5  :style 'released-button))
+   ;; org-mode: Make drawers and special keywords (like scheduled) to be very bleak
+   ((org-special-keyword &override)  :foreground grey)
+   ((org-drawer          &override)  :foreground grey)
+   ;; org-mode: Make ellipsis as bleak as possible and reset any underline and boxing
+   ;; properties
+   (org-ellipsis :underline nil :box nil :foreground fg)
+   ;; org-mode: Make blocks have a slightly different background
    ((org-block &override) :background base1)
    ((org-block-begin-line &override) :foreground fg :slant 'italic)
-   (org-ellipsis :underline nil :box nil :background bg-alt :foreground fg :inherit 'bold)
    ((org-quote &override) :background base1)
    ((org-table &override) :foreground fg)
 
-   ;; Deadlines
-   ((org-upcoming-deadline &override)         :foreground fg)
-   ((org-upcoming-distant-deadline &override) :foreground base5)
-
-   ;; Scheduled things
-   ((org-scheduled &override)            :foreground fg)
-   ((org-scheduled-today &override)      :foreground fg)
-   ((org-scheduled-previously &override) :foreground base5)
+   ;; org-agendamode: make "unimportant" things like distant deadlines and
+   ;; things scheduled for today to be bleak.
+   (org-upcoming-deadline         :foreground base8)
+   (org-upcoming-distant-deadline :foreground fg)
+   (org-scheduled                 :foreground fg)
+   (org-scheduled-today           :foreground fg)
+   (org-scheduled-previously      :foreground base8)
 
    ;; Indent guides character face
    (highlight-indent-guides-character-face :foreground base2)

--- a/themes/doom-homage-white-theme.el
+++ b/themes/doom-homage-white-theme.el
@@ -55,7 +55,7 @@ determine the exact padding."
    ;; face categories -- required for all themes
    (highlight      blue)
    (vertical-bar   (doom-darken base2 0.1))
-   (selection      grey)
+   (selection      base3)
    (builtin        fg)
    (comments       green)
    (doc-comments   (doom-darken comments 0.15))

--- a/themes/doom-homage-white-theme.el
+++ b/themes/doom-homage-white-theme.el
@@ -108,6 +108,9 @@ determine the exact padding."
    ((line-number &override) :foreground (doom-lighten base4 0.15))
    ((line-number-current-line &override) :foreground base8)
 
+   ;; Override secondary selection
+   ((secondary-selection &override) :background base0)
+
    ;; Change swiper colours, background and foreground are too close
    ((swiper-match-face-1 &override) :foreground bg :background fg)
    ((swiper-line-face    &override) :background (doom-lighten blue 0.70) :foreground fg)

--- a/themes/doom-homage-white-theme.el
+++ b/themes/doom-homage-white-theme.el
@@ -174,7 +174,7 @@ determine the exact padding."
    ;; grab attention
    ((org-todo &override) :foreground red)
    ;; org-mode: make tags and dates to have pretty box around them
-   ((org-tag &override)   :foreground fg :background base1
+   ((org-tag &override)   :foreground fg :background yellow-alt
     :box `(:line-width -1 :color ,base5 :style 'released-button))
    ((org-date &override)  :foreground fg :background base1
     :box `(:line-width -1 :color ,base5  :style 'released-button))

--- a/themes/doom-homage-white-theme.el
+++ b/themes/doom-homage-white-theme.el
@@ -43,7 +43,7 @@ determine the exact padding."
    (fg         '("#383a42" "#424242" "black"        ))
    (fg-alt     '("#c6c7c7" "#c7c7c7" "brightblack"  ))
 
-   (grey       base8)
+   (grey       base5)
    (red        '("#e45649" "#e45649" "red"          ))
    (orange     '("#8a3b3c" "#dd8844" "brightred"    ))
    (green      '("#556b2f" "#556b2f" "green"        ))
@@ -110,10 +110,13 @@ determine the exact padding."
     :foreground doc-comments
     :slant 'italic)
 
-   ((secondary-selection &override) :background grey :foreground bg :extend t)
-
    ((line-number &override) :foreground (doom-lighten base4 0.15))
    ((line-number-current-line &override) :foreground base8)
+
+   ;; Change swiper colours, background and foreground are too close
+   ((swiper-match-face-1 &override) :foreground bg :background fg)
+   ((swiper-line-face    &override) :background (doom-lighten blue 0.70) :foreground fg)
+   ((ivy-minibuffer-match-face-1 &override) :foreground (doom-darken grey 0.70))
 
    ;; Apply bold value for different things
    (font-lock-builtin-face       :inherit 'bold)


### PR DESCRIPTION
These themes were evolving for several years already in my personal
emacs configuration and finally moved to doom-themes framework. Main
idea of these themes is to reduce amount of colours to bare minimum, yet
preserve bright and sharp look of main elements.

I took doom-one and doom-one-light themes as an initial carcass for this
transformation.

White theme using palette inspired by various editors from 2000s, with a
lot of inspiration from eziam theme (thblt/eziam-theme-emacs) and tao
theme (11111000000/tao-theme-emacs).

Black theme is (manually) inverted white theme with a focus of having
pitch-black backgrounds. I also incorporated several ideas from jbeans
theme (synic/jbeans-emacs).

---

I used slightly modified eziam theme test files and my personal org-mode buffers to produce screenshots from below. I can produce different screenshots on request.

White theme:
![homage-white](https://user-images.githubusercontent.com/15213728/88462056-eb8dfc80-cea8-11ea-8492-6bb85eb128c8.png)

Black theme:
![homage-black](https://user-images.githubusercontent.com/15213728/88462059-ecbf2980-cea8-11ea-9d12-aeba56b71959.png)