### PR TITLE
Update name of doom's custom hideshow folded face

### DIFF
--- a/doom-themes-base.el
+++ b/doom-themes-base.el
@@ -661,9 +661,9 @@
     (helpful-heading :weight 'bold :height 1.2)
 
     ;; hideshow
-    (+doom-folded-face :inherit 'font-lock-comment-face
-                       :weight 'light
-                       :background (doom-darken bg 0.125))
+    (+fold-hideshow-folded-face :inherit 'font-lock-comment-face
+                                :weight 'light
+                                :background (doom-darken bg 0.125))
 
     ;; highlight-indentation-mode
     (highlight-indentation-face                :inherit 'hl-line)


### PR DESCRIPTION
Doom no longer uses the name `+doom-folded-face`. It's now called [+fold-hideshow-folded-face](https://github.com/hlissner/doom-emacs/blob/050ac737895110f581a19bd6c63b8bc80598da18/modules/editor/fold/autoload/hideshow.el#L3-L6).