### PR TITLE
Update nord color to use a more true background

### DIFF
--- a/themes/doom-nord-theme.el
+++ b/themes/doom-nord-theme.el
@@ -40,7 +40,7 @@ determine the exact padding."
   "A dark theme inspired by Nord."
 
   ;; name        default   256       16
-  ((bg         '("#2E3440" nil       nil            ))
+  ((bg         '("#3B4252" nil       nil            ))
    (bg-alt     '("#272C36" nil       nil            ))
    (base0      '("#191C25" "black"   "black"        ))
    (base1      '("#242832" "#1e1e1e" "brightblack"  ))


### PR DESCRIPTION
The background color used should be for background not not the editor pane it self. much like the dark version of the website https://www.nordtheme.com/docs/colors-and-palettes

Ideally the background color should/could be used for the line numbers - that would look good and make the main editor "pop" / seem elivated.