### PR TITLE
Fix spacegrey brighter comment color

### DIFF
--- a/themes/doom-spacegrey-theme.el
+++ b/themes/doom-spacegrey-theme.el
@@ -64,7 +64,7 @@ determine the exact padding."
    (vertical-bar   (doom-darken bg 0.25))
    (selection      base4)
    (builtin        orange)
-   (comments       base5)
+   (comments       (if doom-spacegrey-brighter-comments dark-cyan base5))
    (doc-comments   (doom-lighten (if doom-spacegrey-brighter-comments dark-cyan base5) 0.25))
    (constants      orange)
    (functions      blue)


### PR DESCRIPTION
The setting only applied to doc comments, which are a small subset of actual comments.