### PR TITLE
Flatwhite: Add blue highlight to variable names

### DIFF
--- a/themes/doom-flatwhite-theme.el
+++ b/themes/doom-flatwhite-theme.el
@@ -453,14 +453,14 @@ determine the exact padding."
     (js2-external-variable :foreground fg)
 
     ;; racket
-    (racket-keyword-argument-face :foreground fw-blue-text
-                                  :background fw-blue-blend)
+    (racket-keyword-argument-face :foreground fw-orange-text
+                                  :background fw-orange-blend)
     (racket-selfeval-face :foreground fw-teal-text
                           :background fw-teal-blend)
 
     ;; clojure
-    (clojure-keyword-face :foreground fw-blue-text
-                          :background fw-blue-blend)
+    (clojure-keyword-face :foreground fw-orange-text
+                          :background fw-orange-blend)
 
     ;; fill column
     (hl-fill-column-face :foreground fg

--- a/themes/doom-flatwhite-theme.el
+++ b/themes/doom-flatwhite-theme.el
@@ -11,6 +11,11 @@
   :group 'doom-flatwhite-theme
   :type 'boolean)
 
+(defcustom doom-flatwhite-no-highlight-variables nil
+  "If non-nil, removes highlight on variable names"
+  :group 'doom-flatwhite-theme
+  :type 'boolean)
+
 (defcustom doom-fw-padded-modeline doom-themes-padded-modeline
   "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
 determine the exact padding."
@@ -118,6 +123,7 @@ determine the exact padding."
 
    ;; custom categories
    (-modeline-bright doom-flatwhite-brighter-modeline)
+   (-no-highlight-variables doom-flatwhite-no-highlight-variables)
    (-modeline-pad
     (when doom-fw-padded-modeline
       (if (integerp doom-fw-padded-modeline) doom-fw-padded-modeline 4)))
@@ -150,7 +156,10 @@ determine the exact padding."
       :foreground doc-comments
       :slant 'italic)
     (font-lock-type-face                 :inherit 'default)
-    (font-lock-variable-name-face        :foreground fg)
+
+    (font-lock-variable-name-face
+     :foreground (if -no-highlight-variables fg fw-blue-text)
+     :background (if -no-highlight-variables bg fw-blue-blend ))
     (font-lock-warning-face              :background fw-red-blend
                                          :foreground fw-red-text)
     (font-lock-negation-char-face        :inherit 'default)


### PR DESCRIPTION
As discussed in https://github.com/hlissner/emacs-doom-themes/pull/514

The original [flatwhite-syntax](https://github.com/biletskyy/flatwhite-syntax) theme for Atom does not highlight variable names. However, the [Sublime Text](https://github.com/Willamin/flatwhite) version of the theme does highlight variable names in blue.

This change adds a blue highlight to variable names, with a config variable (`doom-flatwhite-no-highlight-variables`) to turn the highlight off, for those who prefer the original theme.

This also changes the highlight color for keywords in `racket` and `clojure` (for example: `#:stuff` and `:stuff` respectively) from blue to orange, to better fit with the new usage of blue as the variable name color.

## Screenshots

### After

![flatwhite-var-highlight](https://user-images.githubusercontent.com/1540054/93306331-9bbc1980-f7f7-11ea-9ede-cc7beda60b56.png)


### Before

Or, with `(setq doom-flatwhite-no-highlight-variables t)`

![flatwhite-no-var-highlight](https://user-images.githubusercontent.com/1540054/93306339-9e1e7380-f7f7-11ea-9aa1-8feaba5e0d7e.png)

