### PR TITLE
doom-gruvbox-light: fix cursor bug, remove line numbers background

### DIFF
--- a/themes/doom-gruvbox-light-theme.el
+++ b/themes/doom-gruvbox-light-theme.el
@@ -146,14 +146,14 @@ background contrast. All other values default to \"medium\"."
     :foreground doc-comments
     :slant 'italic)
 
-   (cursor    :foreground fg)
+   (cursor :background base4)
 
    ;; Line number
-   ((line-number &override) :foreground base4 :background base1)
-   ((line-number-current-line &override) :foreground orange :background (doom-lighten bg 0.1))
-   (linum     :foreground base4 :background base2)
-   (linum-highlight-face :foreground orange :background base2)
-   (linum-relative-current-face :foreground orange :background base2)
+   ((line-number &override) :foreground base4)
+   ((line-number-current-line &override) :foreground orange)
+   (linum :foreground base4)
+   (linum-highlight-face :foreground orange)
+   (linum-relative-current-face :foreground orange)
 
    (doom-modeline-bar :background (if -modeline-bright modeline-bg highlight))
 


### PR DESCRIPTION
### Cursor fix and new option
- fixes the cursor being white after startup and black after reloading the theme 
- cursor is now grey, as in the [original gruvbox light](https://github.com/morhetz/gruvbox#light-mode) 
~~- the black cursor can be brought back by setting `doom-gruvbox-light-darker-cursor` to `t`~~

### Further port improvement

- in the [original](https://github.com/morhetz/gruvbox#light-mode) version, line numbers have no special background
