### PR TITLE
Fix org source block indicators' visibility for doom-plain

### DIFF
--- a/themes/doom-plain-theme.el
+++ b/themes/doom-plain-theme.el
@@ -101,6 +101,14 @@ determine the exact padding."
    (hl-line
     :background base8)
 
+   (org-block-begin-line
+    :foreground base2
+    :background base3)
+
+   (org-block-end-line
+    :foreground base2
+    :background base3)
+   
    (org-level-1
     :weight 'bold
     :foreground fg


### PR DESCRIPTION
Before:
![2020-10-29-095354_1920x1080_scrot](https://user-images.githubusercontent.com/53148859/97525842-c809af00-19cd-11eb-8801-c45768aad337.png)

After:
![2020-10-29-095252_1920x1080_scrot](https://user-images.githubusercontent.com/53148859/97525851-cf30bd00-19cd-11eb-97e7-f0c4ce0d333a.png)

This fixes visibility issues with org babel blocks' indicators.
