### PR TITLE
solarized-dark: change variables to blue

### DIFF
--- a/themes/doom-solarized-dark-theme.el
+++ b/themes/doom-solarized-dark-theme.el
@@ -81,7 +81,7 @@ determine the exact padding."
    (operators      orange)
    (type           yellow)
    (strings        cyan)
-   (variables      fg)
+   (variables      blue)
    (numbers        magenta)
    (region         base0)
    (error          red)


### PR DESCRIPTION
This is in line with solarized-light, which is more readable imho.