### PR TITLE
Fix variable typo

### DIFF
--- a/themes/doom-monokai-pro-theme.el
+++ b/themes/doom-monokai-pro-theme.el
@@ -73,7 +73,7 @@ Can be an integer to determine the exact padding."
    (modeline-fg-alt comments)
    (-modeline-pad
     (when doom-monokai-pro-padded-modeline
-      (if (integerp doom-monokai-pror-padded-modeline)
+      (if (integerp doom-monokai-pro-padded-modeline)
           doom-monokai-pro-padded-modeline
         4))))
 


### PR DESCRIPTION
A small typo in the variable name in `doom-monokai-pro-theme.el`.