### PR TITLE
Add new theme: doom-1337

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ DOOM Themes is an opinionated UI plugin and pack of themes extracted from my
   - [X] `doom-wilmersdorf`: port of Ian Pan's [Wilmersdorf] (thanks to [ema2159])
   - [X] `doom-zenburn`: port of the popular [Zenburn] theme (thanks to [jsoa])
   - [ ] `doom-mono-dark` / `doom-mono-light`: a minimalistic, monochromatic theme
-  - [ ] `doom-tron`: based on Tron Legacy from [daylerees]
+  - [ ] `doom-tron`: based on Tron Legacy from [daylerees' themes][daylerees]
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ DOOM Themes is an opinionated UI plugin and pack of themes extracted from my
   - [X] `doom-wilmersdorf`: port of Ian Pan's [Wilmersdorf] (thanks to [ema2159])
   - [X] `doom-zenburn`: port of the popular [Zenburn] theme (thanks to [jsoa])
   - [ ] `doom-mono-dark` / `doom-mono-light`: a minimalistic, monochromatic theme
-  - [ ] `doom-tron`: based on Tron Legacy from [daylerees' themes][daylerees]
+  - [ ] `doom-tron`: based on Tron Legacy from [daylerees]
+  - [X] `doom-1337`: ported from VSCode's 1337 Theme
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ DOOM Themes is an opinionated UI plugin and pack of themes extracted from my
   - [X] `doom-one-light`: light version of doom-one (thanks to [ztlevi])
   - [X] `doom-vibrant`: a slightly more vibrant version of `doom-one`
 - Additional themes
+  - [X] `doom-1337`: ported from [VSCode's 1337 Theme][vscode-1337]
   - [X] `doom-acario-dark`: an original dark theme (thanks to [gagbo])
   - [X] `doom-acario-light`: an original light theme (thanks to [gagbo])
   - [X] `doom-city-lights`: based on Atom's [City lights][city-lights] (thanks to [fuxialexander])
@@ -72,7 +73,6 @@ DOOM Themes is an opinionated UI plugin and pack of themes extracted from my
   - [X] `doom-zenburn`: port of the popular [Zenburn] theme (thanks to [jsoa])
   - [ ] `doom-mono-dark` / `doom-mono-light`: a minimalistic, monochromatic theme
   - [ ] `doom-tron`: based on Tron Legacy from [daylerees]
-  - [X] `doom-1337`: ported from VSCode's 1337 Theme
 
 ## Features
 
@@ -258,4 +258,5 @@ pointers. Additional theme and plugin support requests are welcome too.
 [hyakt]: https://github.com/hyakt
 [rouge theme]: https://github.com/josefaidt/rouge-theme 
 [JordanFaust]: https://github.com/JordanFaust
+[vscode-1337]: https://github.com/microsoft/vscode-themes/tree/main/1337
 [Zenburn]: https://github.com/bbatsov/zenburn-emacs

--- a/themes/doom-1337-theme.el
+++ b/themes/doom-1337-theme.el
@@ -1,0 +1,228 @@
+;;; doom-1337-theme.el --- inspired by 1337 Theme  -*- no-byte-compile: t; -*-
+(require 'doom-themes)
+
+;;
+(defgroup doom-1337-theme nil
+  "Options for doom-themes"
+  :group 'doom-themes)
+
+(defcustom doom-1337-padded-modeline doom-themes-padded-modeline
+  "If non-nil, adds a 4px padding to the mode-line.
+Can be an integer to determine the exact padding."
+  :group 'doom-1337-theme
+  :type '(choice integer boolean))
+
+(defcustom doom-1337-blue-modeline nil
+  "If non-nil, mode-line's color will be blue instead of the default purple."
+  :group 'doom-1337-theme
+  :type '(choice integer boolean))
+
+;;
+(def-doom-theme doom-1337
+  "A dark theme inspired by 1337 Theme"
+
+  ;; name        default   256       16
+  ((bg         '("#191919" "#191919" nil))
+   (bg-alt     '("#252526" "#222222"  nil))
+   (base0      '("#171F24" "#111122"   "black"))
+   (base1      '("#1C1C1C" "#1C1C1C" "brightblack"))
+   (base2      '("#121212" "#626262" "brightblack"))
+   (base3      '("#3D3D3D" "#3D3D3D" "brightblack"))
+   (base4      '("#4b474c" "#444444" "brightblack"))
+   (base5      '("#515151" "#515151" "brightblack"))
+   (base6      '("#6D6D6D" "#6D6D6D" "brightblack"))
+   (base7      '("#777778" "#767676" "brightblack"))
+   (base8      '("#f4f4f4" "#a8a8a8" "white"))
+   (fg         '("#d4d4d4" "#d4d4d4" "brightwhite"))
+   (fg-alt     '("#AEAFAD" "#bcbcbc" "white"))
+
+   (grey base7)
+   (white        '("#FFFFFF" "#FFFFFF" "white"))
+   (red          '("#FF5E5E" "#FF5E5E" "red"))
+   (orange       '("#FC9354" "#FC9354" "brightred"))
+   (green        '("#468800" "#468800" "green"))
+   (light-green  '("#B5CEA8" "#BBCCAA" "green"))
+   (teal         '("#35CDAF" "#33CCAA" "brightgreen"))
+   (yellow       '("#E9FDAC" "#E9FDAC" "brightyellow"))
+   (light-yellow '("#FBE3BF" "#FBE3BF" "brightyellow"))
+   (blue         '("#8CDAFF" "#8CDAFF" "brightblue"))
+   (dark-blue    '("#6699CC" "#6699CC" "blue"))
+   (magenta      '("#C586C0" "#CC88CC" "brightmagenta"))
+   (violet       '("#BB80B3" "#BB88BB" "magenta"))
+   (dark-violet  '("#68217A" "#662277" "magenta"))
+   (cyan         '("#85DDFF" "#5FD7FF" "brightcyan"))
+   (dark-cyan    '("#207FA1" "#2277AA" "cyan"))
+
+   ;; component focused
+   (bottomline-blue '("#2467D0" "#2467D0" "blue"))
+   (vcmodified-blue '("#007B9F" "#007B9F" "blue"))
+   (vcdeleted-red '("#9D0012" "#9D0012" "red"))
+
+   ;; face categories -- required for all themes
+   (highlight      white)
+   (vertical-bar   base2)
+   (selection      base5)
+   (builtin        dark-blue)
+   (comments       base6)
+   (doc-comments   base6)
+   (constants      orange)
+   (functions      blue)
+   (keywords       red)
+   (methods        dark-blue)
+   (operators      red)
+   (type           yellow)
+   (strings        light-yellow)
+   (variables      yellow)
+   (numbers        orange)
+   (region         (doom-darken base5 0.5))
+   (error          red)
+   (warning        yellow)
+   (success        green)
+   (vc-modified    vcmodified-blue)
+   (vc-added       green)
+   (vc-deleted     red)
+
+   ;; custom categories
+   (modeline-bg     (if doom-1337-blue-modeline base8 bottomline-blue))
+   (modeline-bg-alt (doom-darken bg 0.01))
+   (modeline-fg     base8)
+   (modeline-fg-alt blue)
+
+   (-modeline-pad
+    (when doom-1337-padded-modeline
+      (if (integerp doom-1337-padded-modeline) doom-1337-padded-modeline 4))))
+
+  ;; --- base faces ------------------------
+  ((highlight            :background highlight  :foreground base8 :distant-foreground base8)
+   ((lazy-highlight &override) :background base4 :foreground fg :distant-foreground fg :bold bold)
+   (doom-modeline-buffer-path       :foreground green :weight 'bold)
+   (doom-modeline-buffer-major-mode :inherit 'doom-modeline-buffer-path)
+
+   (mode-line
+    :background modeline-bg :foreground modeline-fg
+    :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg)))
+
+   (mode-line-inactive
+    :background modeline-bg-alt :foreground modeline-fg-alt
+    :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg-alt)))
+
+   (mode-line-emphasis
+    :foreground fg
+    :weight 'bold)
+
+   (solaire-mode-line-face
+    :background modeline-bg :foreground modeline-fg
+    :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg)))
+   (solaire-mode-line-inactive-face
+    :background modeline-bg-alt :foreground modeline-fg-alt
+    :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg-alt)))
+
+   (fringe :background bg-alt)
+
+   ;; --- major-mode faces ------------------------
+   ;; all-the-icons
+   (all-the-icons-dblue    :foreground bottomline-blue)
+
+   ;; man-mode
+   (Man-overstrike :inherit 'bold :foreground magenta)
+   (Man-underline :inherit 'underline :foreground blue)
+
+   ;; centaur-tabs
+   (centaur-tabs-active-bar-face :background base6)
+   (centaur-tabs-selected-modified :inherit 'centaur-tabs-selected
+				   :foreground fg
+				   :weight 'bold)
+   (centaur-tabs-unselected-modified :inherit 'centaur-tabs-unselected
+				     :foreground fg
+				     :weight 'bold)
+   (centaur-tabs-modified-marker-selected :inherit 'centaur-tabs-selected
+					  :foreground fg)
+   (centaur-tabs-modified-marker-unselected :inherit 'centaur-tabs-unselected
+					    :foreground fg)
+   ;; dashboard
+   (dashboard-heading :foreground green :weight 'bold)
+
+   ;; doom-modeline
+   (doom-modeline-bar :background (if doom-1337-blue-modeline base8 bottomline-blue))
+   (doom-modeline-info :inherit 'mode-line-emphasis)
+   (doom-modeline-urgent :inherit 'mode-line-emphasis)
+   (doom-modeline-warning :inherit 'mode-line-emphasis)
+   (doom-modeline-debug :inherit 'mode-line-emphasis)
+   (doom-modeline-buffer-minor-mode :inherit 'mode-line-emphasis :weight 'bold)
+   (doom-modeline-project-dir :inherit 'mode-line-emphasis :weight 'bold)
+   (doom-modeline-project-parent-dir :inherit 'mode-line-emphasis :weight 'bold)
+   (doom-modeline-persp-name :inherit 'mode-line-emphasis :weight 'bold)
+   (doom-modeline-buffer-file :inherit 'mode-line-emphasis :weight 'bold)
+   (doom-modeline-buffer-modified :inherit 'mode-line-emphasis :weight 'bold)
+   (doom-modeline-lsp-success :inherit 'mode-line-emphasis :weight 'bold)
+   (doom-modeline-buffer-path :inherit 'mode-line-emphasis :weight 'bold)
+   (doom-modeline-buffer-project-root :inherit 'mode-line-emphasis)
+   (doom-modeline-evil-insert-state :foreground cyan)
+   (doom-modeline-evil-visual-state :foreground yellow)
+
+   ;; org-mode
+   ((org-block &override) :background base2)
+   ((org-block-background &override) :background base2)
+   ((org-block-begin-line &override) :background base2)
+
+   ;; --- plugin faces -------------------
+   ;; company
+   (company-tooltip-selection     :background region)
+
+   ;; css-mode / scss-mode
+   (css-proprietary-property :foreground orange)
+   (css-property             :foreground green)
+   (css-selector             :foreground blue)
+
+   ;; dired-k
+   (dired-k-commited :foreground base4)
+   (dired-k-modified :foreground vc-modified)
+   (dired-k-ignored :foreground cyan)
+   (dired-k-added    :foreground vc-added)
+
+   ;; ivy
+   (counsel-active-mode :foreground (doom-lighten base6 0.1))
+   (ivy-minibuffer-match-face-2 :foreground (doom-lighten base6 0.1) :weight 'extra-bold)
+
+   ;; js2-mode
+   (js2-jsdoc-tag              :foreground magenta)
+   (js2-object-property        :foreground cyan)
+   (js2-object-property-access :foreground cyan)
+   (js2-function-param         :foreground violet)
+   (js2-jsdoc-type             :foreground base8)
+   (js2-jsdoc-value            :foreground cyan)
+
+   ;; lsp-mode
+   (lsp-lens-face              :foreground base7 :height 0.8)
+
+   ;; rainbow-delimiters
+   (rainbow-delimiters-depth-1-face :foreground magenta)
+   (rainbow-delimiters-depth-2-face :foreground orange)
+   (rainbow-delimiters-depth-3-face :foreground green)
+   (rainbow-delimiters-depth-4-face :foreground cyan)
+   (rainbow-delimiters-depth-5-face :foreground violet)
+   (rainbow-delimiters-depth-6-face :foreground yellow)
+   (rainbow-delimiters-depth-7-face :foreground blue)
+   (rainbow-delimiters-depth-8-face :foreground teal)
+   (rainbow-delimiters-depth-9-face :foreground dark-cyan)
+
+   ;; org-pomodoro
+   (org-pomodoro-mode-line :inherit 'mode-line-emphasis) ; unreadable otherwise
+   (org-pomodoro-mode-line-overtime :inherit 'org-pomodoro-mode-line)
+   (org-pomodoro-mode-line-break :inherit 'org-pomodoro-mode-line)
+
+   ;; rjsx-mode
+   (rjsx-tag :foreground blue)
+   (rjsx-attr :foreground cyan :slant 'italic :weight 'medium)
+
+   ;; treemacs
+   (treemacs-root-face :foreground fg :weight 'ultra-bold :height 1.2)
+   (doom-themes-treemacs-root-face :foreground fg :weight 'ultra-bold :height 1.2)
+   (doom-themes-treemacs-file-face :foreground fg)
+   (treemacs-directory-face :foreground fg)
+   (treemacs-git-modified-face :foreground blue)
+
+   ;; tooltip
+   (tooltip :background base2 :foreground fg)))
+
+(provide 'doom-1337-theme)


### PR DESCRIPTION
This is a port of 1337 theme based on [microsoft/vscode-themes/1337](https://github.com/microsoft/vscode-themes/tree/master/1337)

The original 1337 theme in VSCode
![Screenshot from 2020-12-07 11-16-35](https://user-images.githubusercontent.com/63459097/101305708-391a6d00-387e-11eb-82a3-f920b918b1e6.png)

The doom-1337 theme in Emacs
![Screenshot from 2020-12-07 11-17-59](https://user-images.githubusercontent.com/63459097/101305784-5f400d00-387e-11eb-95cb-54f509a2cc6d.png)

 