### PR TITLE
Add: smart-mode-line (sml/) faces

### DIFF
--- a/doom-themes-base.el
+++ b/doom-themes-base.el
@@ -958,6 +958,18 @@
     ((show-paren-match &inherit paren-face-match))
     ((show-paren-mismatch &inherit paren-face-mismatch))
 
+    ;; smart-mode-line
+    (sml/charging          :foreground green)
+    (sml/discharging       :foreground yellow :weight 'bold)
+    (sml/filename          :foreground violet :weight 'bold)
+    (sml/git               :foreground blue)
+    (sml/modified          :foreground cyan)
+    (sml/outside-modified  :foreground cyan)
+    (sml/process           :weight 'bold)
+    (sml/read-only         :foreground cyan)
+    (sml/sudo              :foreground orange :weight 'bold)
+    (sml/vc-edited         :foreground green)
+
     ;; smartparens
     (sp-pair-overlay-face :background region)
 


### PR DESCRIPTION
This themes faces in Artur Malabarba's `smart-mode-line` package: https://github.com/Malabarba/smart-mode-line/

![sml](https://user-images.githubusercontent.com/601365/102694041-21c77200-41e4-11eb-85ef-6b05c960ac07.png)

Without this patch, it looks like this: 
![without](https://user-images.githubusercontent.com/601365/102694653-0cecdd80-41e8-11eb-86ad-7f6904cda0fe.png)



Thanks for your work on doom-themes.