### PR TITLE
Solarized dark: customizable color of constants

### DIFF
--- a/themes/doom-solarized-dark-theme.el
+++ b/themes/doom-solarized-dark-theme.el
@@ -21,6 +21,11 @@
   :group 'doom-solarized-dark-theme
   :type 'boolean)
 
+(defcustom doom-solarized-dark-make-constants-blue nil
+  "If not-nil, makes constants blue instead of magenta"
+  :group 'doom-solarized-dark-theme
+  :type 'boolean)
+
 (defcustom doom-solarized-dark-comment-bg doom-solarized-dark-brighter-comments
   "If non-nil, comments will have a subtle, darker background. Enhancing their
 legibility."
@@ -74,7 +79,7 @@ determine the exact padding."
    (builtin        blue)
    (comments       (if doom-solarized-dark-brighter-comments blue base5))
    (doc-comments   teal)
-   (constants      magenta)
+   (constants      (if doom-solarized-dark-make-constants-blue blue magenta))
    (functions      blue)
    (keywords       green)
    (methods        cyan)


### PR DESCRIPTION
Adding a customization option for solarized dark theme that allows one to make the color of the constants blue instead of magenta. The reason for it is that I work with C++ alot and in C++ code, a lot of things (primary example: namespace names) are considered constants. This results in a lot of magenta on screen, which is a bit hard on the eyes.
