### PR TITLE
New theme doom-solarized-dark-high-contrast

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ DOOM Themes is an opinionated UI plugin and pack of themes extracted from my
   - [X] `doom-rouge`: ported from [VSCode's Rouge Theme][rouge theme]  (thanks to [JordanFaust])
   - [X] `doom-snazzy`: a dark theme inspired in Atom's [Hyper Snazzy][snazzy] (thanks to [ar1a])
   - [X] `doom-solarized-dark`: dark variant of [Solarized][solarized] (thanks to [ema2159])
+  - [X] `doom-solarized-dark-high-contrast`: high contrast dark variant of [Solarized][solarized] (thanks to [jmorag])
   - [X] `doom-solarized-light`: light variant of [Solarized][solarized] (thanks to [fuxialexander])
   - [X] `doom-sourcerer`: based on [Sourcerer][sourcerer] (thanks to [defphil])
   - [X] `doom-spacegrey`: [I'm sure you've heard of it][spacegrey] (thanks to [teesloane])
@@ -228,6 +229,7 @@ pointers. Additional theme and plugin support requests are welcome too.
 [issues]: https://github.com/hlissner/emacs-doom-themes/issues
 [Iosvkem]: https://github.com/neutaaaaan/iosvkem
 [juanwolf]: https://github.com/juanwolf
+[jmorag]: https://github.com/jmorag
 [JongW]: https://github.com/JongW
 [jsoa]: https://github.com/jsoa
 [jwintz]: https://github.com/jwintz

--- a/README.md
+++ b/README.md
@@ -78,60 +78,61 @@ These themes were written by the author of this package and are most maintained:
 These themes were submitted to us by the community. We welcome PRs to help us
 maintain them and address inconsistencies:
 
-| Name                    | Description                                                                                                  |
-|-------------------------|--------------------------------------------------------------------------------------------------------------|
-| `doom-1337`             | ported from [VSCode's 1337 Theme][vscode-1337]                                                               |
-| `doom-acario-dark`      | an original dark theme (thanks to [gagbo])                                                                   |
-| `doom-acario-light`     | an original light theme (thanks to [gagbo])                                                                  |
-| `doom-ayu-dark`         | Light variant from [Ayu] themes (thanks to [LoveSponge])                                                     |
-| `doom-ayu-light`        | Dark variant from [Ayu] themes(thanks to [LoveSponge])                                                       |
-| `doom-badger`           | Based on [original Badger theme](https://github.com/ccann/badger-theme)                                      |
-| `doom-challenger-deep`  | based on Vim's [Challenger deep][challenger-deep] theme (thanks to [fuxialexander])                          |
-| `doom-city-lights`      | based on Atom's [City lights][city-lights] (thanks to [fuxialexander])                                       |
-| `doom-dark+`            | ported from VS Code's [Dark+][dark+] theme (thanks to [ema2159])                                             |
-| `doom-dracula`          | an implementation of [Dracula] theme (thanks to [fuxialexander])                                             |
-| `doom-ephemeral`        | inspired in the Ephemeral Theme from [elenapan's dotfiles] (thanks to [karetsu])                             |
-| `doom-fairy-floss`      | a candy colored Sublime theme by [sailorhg] (thanks to [ema2159])                                            |
-| `doom-flatwhite`        | a unique light theme ported from [Flatwhite Syntax][flatwhite] (thanks to [ShaneKilkelly])                   |
-| `doom-gruvbox-light`    | adapted from Morhetz's [Gruvbox] light variant (thanks for [jsoa])                                           |
-| `doom-gruvbox`          | adapted from Morhetz's [Gruvbox] (thanks to [JongW])                                                         |
-| `doom-henna`            | based on VS Code's [Henna] (thanks to [jsoa])                                                                |
-| `doom-homage-black`     | dark variant of doom-homage white. (thanks to [mskorzhinskiy])                                               |
-| `doom-homage-white`     | a minimalistic, colorless theme, inspired by [eziam], [tao] and [jbeans] themes. (thanks to [mskorzhinskiy]) |
-| `doom-horizon`          | ported from VS Code's [Horizon] (thanks to [karetsu])                                                        |
-| `doom-Iosvkem`          | adapted from [Iosvkem] (thanks to [neutaaaaan])                                                              |
-| `doom-laserwave`        | a clean 80's synthwave / outrun theme inspired by VS Code's [laserwave][laserwave] (thanks to [hyakt])       |
-| `doom-manegarm`         | an original autumn-inspired dark theme (thanks to [kenranunderscore])                                        |
-| `doom-material`         | adapted from [Material Themes] (thanks to [tam5])                                                            |
-| `doom-miramare`         | a port of [Franbach's][franbach] [Miramare], a variant of gruvbox theme (thanks to [sagittaros])             |
-| `doom-molokai`          | a theme based on Texmate's Monokai                                                                           |
-| `doom-monokai-classic`  | port of [Monokai]'s Classic variant (thanks to [ema2159])                                                    |
-| `doom-monokai-pro`      | port of [Monokai]'s Pro variant (thanks to [kadenbarlow])                                                    |
-| `doom-moonlight`        | ported from VS Code's [Moonlight Theme] (thanks to [Brettm12345])                                            |
-| `doom-nord-light`       | light variant of [Nord][nord] (thanks to [fuxialexander])                                                    |
-| `doom-nord`             | dark variant of [Nord][nord] (thanks to [fuxialexander])                                                     |
-| `doom-nova`             | adapted from [Nova] (thanks to [bigardone])                                                                  |
-| `doom-oceanic-next`     | adapted from [Oceanic Next] theme (thanks to [juanwolf])                                                     |
-| `doom-old-hope`         | based on [An Old Hope] theme (thanks to [teesloane])                                                         |
-| `doom-opera-light`      | an original light theme (thanks to [jwintz])                                                                 |
-| `doom-opera`            | an original dark theme (thanks to [jwintz])                                                                  |
-| `doom-outrun-electric`  | a neon colored theme inspired in VS Code's [Outrun Electric][outrun] (thanks to [ema2159])                   |
-| `doom-palenight`        | adapted from [Material Themes] (thanks to [Brettm12345])                                                     |
-| `doom-peacock`          | based on Peacock from [daylerees' themes][daylerees] (thanks to [teesloane])                                 |
-| `doom-plain-dark`       | based on [plain] (thanks to [das-s])                                                                         |
-| `doom-plain`            | based on [plain] (thanks to [mateossh])                                                                      |
-| `doom-rouge`            | ported from [VSCode's Rouge Theme][rouge theme]  (thanks to [JordanFaust])                                   |
-| `doom-shades-of-purple` | a purple and vibrant theme inspired by VSCode's [Shades of Purple][shades-of-purple] (thanks to [jwbaldwin]) |
-| `doom-snazzy`           | a dark theme inspired in Atom's [Hyper Snazzy][snazzy] (thanks to [ar1a])                                    |
-| `doom-solarized-dark`   | dark variant of [Solarized][solarized] (thanks to [ema2159])                                                 |
-| `doom-solarized-light`  | light variant of [Solarized][solarized] (thanks to [fuxialexander])                                          |
-| `doom-sourcerer`        | based on [Sourcerer][sourcerer] (thanks to [defphil])                                                        |
-| `doom-spacegrey`        | [I'm sure you've heard of it][spacegrey] (thanks to [teesloane])                                             |
-| `doom-tomorrow-day`     | [Tomorrow][tomorrow]'s light variant (thanks to [emacswatcher])                                              |
-| `doom-tomorrow-night`   | one of the dark variants of [Tomorrow][tomorrow] (thanks to [emacswatcher])                                  |
-| `doom-wilmersdorf`      | port of Ian Pan's [Wilmersdorf] (thanks to [ema2159])                                                        |
-| `doom-xcode`            | Based off of Apple's Xcode Dark theme (thanks to [kadenbarlow])                                              |
-| `doom-zenburn`          | port of the popular [Zenburn] theme (thanks to [jsoa])                                                       |
+| Name                                | Description                                                                                                  |
+|-------------------------------------|--------------------------------------------------------------------------------------------------------------|
+| `doom-1337`                         | ported from [VSCode's 1337 Theme][vscode-1337]                                                               |
+| `doom-acario-dark`                  | an original dark theme (thanks to [gagbo])                                                                   |
+| `doom-acario-light`                 | an original light theme (thanks to [gagbo])                                                                  |
+| `doom-ayu-dark`                     | Light variant from [Ayu] themes (thanks to [LoveSponge])                                                     |
+| `doom-ayu-light`                    | Dark variant from [Ayu] themes(thanks to [LoveSponge])                                                       |
+| `doom-badger`                       | Based on [original Badger theme](https://github.com/ccann/badger-theme)                                      |
+| `doom-challenger-deep`              | based on Vim's [Challenger deep][challenger-deep] theme (thanks to [fuxialexander])                          |
+| `doom-city-lights`                  | based on Atom's [City lights][city-lights] (thanks to [fuxialexander])                                       |
+| `doom-dark+`                        | ported from VS Code's [Dark+][dark+] theme (thanks to [ema2159])                                             |
+| `doom-dracula`                      | an implementation of [Dracula] theme (thanks to [fuxialexander])                                             |
+| `doom-ephemeral`                    | inspired in the Ephemeral Theme from [elenapan's dotfiles] (thanks to [karetsu])                             |
+| `doom-fairy-floss`                  | a candy colored Sublime theme by [sailorhg] (thanks to [ema2159])                                            |
+| `doom-flatwhite`                    | a unique light theme ported from [Flatwhite Syntax][flatwhite] (thanks to [ShaneKilkelly])                   |
+| `doom-gruvbox-light`                | adapted from Morhetz's [Gruvbox] light variant (thanks for [jsoa])                                           |
+| `doom-gruvbox`                      | adapted from Morhetz's [Gruvbox] (thanks to [JongW])                                                         |
+| `doom-henna`                        | based on VS Code's [Henna] (thanks to [jsoa])                                                                |
+| `doom-homage-black`                 | dark variant of doom-homage white. (thanks to [mskorzhinskiy])                                               |
+| `doom-homage-white`                 | a minimalistic, colorless theme, inspired by [eziam], [tao] and [jbeans] themes. (thanks to [mskorzhinskiy]) |
+| `doom-horizon`                      | ported from VS Code's [Horizon] (thanks to [karetsu])                                                        |
+| `doom-Iosvkem`                      | adapted from [Iosvkem] (thanks to [neutaaaaan])                                                              |
+| `doom-laserwave`                    | a clean 80's synthwave / outrun theme inspired by VS Code's [laserwave][laserwave] (thanks to [hyakt])       |
+| `doom-manegarm`                     | an original autumn-inspired dark theme (thanks to [kenranunderscore])                                        |
+| `doom-material`                     | adapted from [Material Themes] (thanks to [tam5])                                                            |
+| `doom-miramare`                     | a port of [Franbach's][franbach] [Miramare], a variant of gruvbox theme (thanks to [sagittaros])             |
+| `doom-molokai`                      | a theme based on Texmate's Monokai                                                                           |
+| `doom-monokai-classic`              | port of [Monokai]'s Classic variant (thanks to [ema2159])                                                    |
+| `doom-monokai-pro`                  | port of [Monokai]'s Pro variant (thanks to [kadenbarlow])                                                    |
+| `doom-moonlight`                    | ported from VS Code's [Moonlight Theme] (thanks to [Brettm12345])                                            |
+| `doom-nord-light`                   | light variant of [Nord][nord] (thanks to [fuxialexander])                                                    |
+| `doom-nord`                         | dark variant of [Nord][nord] (thanks to [fuxialexander])                                                     |
+| `doom-nova`                         | adapted from [Nova] (thanks to [bigardone])                                                                  |
+| `doom-oceanic-next`                 | adapted from [Oceanic Next] theme (thanks to [juanwolf])                                                     |
+| `doom-old-hope`                     | based on [An Old Hope] theme (thanks to [teesloane])                                                         |
+| `doom-opera-light`                  | an original light theme (thanks to [jwintz])                                                                 |
+| `doom-opera`                        | an original dark theme (thanks to [jwintz])                                                                  |
+| `doom-outrun-electric`              | a neon colored theme inspired in VS Code's [Outrun Electric][outrun] (thanks to [ema2159])                   |
+| `doom-palenight`                    | adapted from [Material Themes] (thanks to [Brettm12345])                                                     |
+| `doom-peacock`                      | based on Peacock from [daylerees' themes][daylerees] (thanks to [teesloane])                                 |
+| `doom-plain-dark`                   | based on [plain] (thanks to [das-s])                                                                         |
+| `doom-plain`                        | based on [plain] (thanks to [mateossh])                                                                      |
+| `doom-rouge`                        | ported from [VSCode's Rouge Theme][rouge theme]  (thanks to [JordanFaust])                                   |
+| `doom-shades-of-purple`             | a purple and vibrant theme inspired by VSCode's [Shades of Purple][shades-of-purple] (thanks to [jwbaldwin]) |
+| `doom-snazzy`                       | a dark theme inspired in Atom's [Hyper Snazzy][snazzy] (thanks to [ar1a])                                    |
+| `doom-solarized-dark`               | dark variant of [Solarized][solarized] (thanks to [ema2159])                                                 |
+| `doom-solarized-dark-high-contrast` | high contrast dark variant of [Solarized][solarized] (thanks to [jmorag])                                    |
+| `doom-solarized-light`              | light variant of [Solarized][solarized] (thanks to [fuxialexander])                                          |
+| `doom-sourcerer`                    | based on [Sourcerer][sourcerer] (thanks to [defphil])                                                        |
+| `doom-spacegrey`                    | [I'm sure you've heard of it][spacegrey] (thanks to [teesloane])                                             |
+| `doom-tomorrow-day`                 | [Tomorrow][tomorrow]'s light variant (thanks to [emacswatcher])                                              |
+| `doom-tomorrow-night`               | one of the dark variants of [Tomorrow][tomorrow] (thanks to [emacswatcher])                                  |
+| `doom-wilmersdorf`                  | port of Ian Pan's [Wilmersdorf] (thanks to [ema2159])                                                        |
+| `doom-xcode`                        | Based off of Apple's Xcode Dark theme (thanks to [kadenbarlow])                                              |
+| `doom-zenburn`                      | port of the popular [Zenburn] theme (thanks to [jsoa])                                                       |
 
 ### Planned themes
 

--- a/themes/doom-solarized-dark-high-contrast-theme.el
+++ b/themes/doom-solarized-dark-high-contrast-theme.el
@@ -1,0 +1,229 @@
+;;; doom-solarized-dark-high-contrast-theme.el --- inspired by VS Code Solarized Dark -*- no-byte-compile: t; -*-
+(require 'doom-themes)
+
+;;
+(defgroup doom-solarized-dark-high-contrast-theme nil
+  "Options for doom-themes"
+  :group 'doom-themes)
+
+(defcustom doom-solarized-dark-high-contrast-brighter-modeline nil
+  "If non-nil, more vivid colors will be used to style the mode-line."
+  :group 'doom-solarized-dark-high-contrast-theme
+  :type 'boolean)
+
+(defcustom doom-solarized-dark-high-contrast-brighter-comments nil
+  "If non-nil, comments will be highlighted in more vivid colors."
+  :group 'doom-solarized-dark-high-contrast-theme
+  :type 'boolean)
+
+(defcustom doom-solarized-dark-high-contrast-brighter-text t
+  "If non-nil, default text will be brighter."
+  :group 'doom-solarized-dark-high-contrast-theme
+  :type 'boolean)
+
+(defcustom doom-solarized-dark-high-contrast-comment-bg doom-solarized-dark-high-contrast-brighter-comments
+  "If non-nil, comments will have a subtle, darker background. Enhancing their
+legibility."
+  :group 'doom-solarized-dark-high-contrast-theme
+  :type 'boolean)
+
+(defcustom doom-solarized-dark-high-contrast-padded-modeline doom-themes-padded-modeline
+  "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
+determine the exact padding."
+  :group 'doom-solarized-dark-high-contrast-theme
+  :type '(choice integer boolean))
+
+;;
+(def-doom-theme doom-solarized-dark-high-contrast
+  "A dark theme inspired by VS Code Solarized Dark"
+
+  ;; name        default   256       16
+  ((bg         '("#002732" "#002732"       nil     ))
+   (bg-alt     '("#00212B" "#00212B"       nil     ))
+   (base0      '("#01323d" "#01323d"   "black"     ))
+   (base1      '("#03282F" "#03282F" "brightblack" ))
+   (base2      '("#00212C" "#00212C" "brightblack" ))
+   (base3      '("#13383C" "#13383C" "brightblack" ))
+   (base4      '("#56697A" "#56697A" "brightblack" ))
+   (base5      '("#62787f" "#62787f" "brightblack" ))
+   (base6      '("#96A7A9" "#96A7A9" "brightblack" ))
+   (base7      '("#788484" "#788484" "brightblack" ))
+   (base8      '("#626C6C" "#626C6C" "white"       ))
+   (fg-alt     '("#60767e" "#60767e" "white"       ))
+   (fg         '("#8d9fa1" "#8d9fa1" "brightwhite"))
+
+   (grey       base4)
+   (red        '("#ec423a" "#ec423a" "red"          ))
+   (orange     '("#db5823" "#db5823" "brightred"    ))
+   (green      '("#93a61a" "#93a61a" "green"        ))
+   (teal       '("#35a69c" "#33aa99" "brightgreen"  ))
+   (yellow     '("#c49619" "#c49619" "yellow"       ))
+   (blue       '("#3c98e0" "#3c98e0" "brightblue"   ))
+   (dark-blue  '("#3F88AD" "#2257A0" "blue"         ))
+   (magenta    '("#e2468f" "#e2468f" "magenta"      ))
+   (violet     '("#7a7ed2" "#7a7ed2" "brightmagenta"))
+   (cyan       '("#3cafa5" "#3cafa5" "brightcyan"   ))
+   (dark-cyan  '("#03373f" "#03373f" "cyan"         ))
+
+   ;; face categories -- required for all themes
+   (highlight      blue)
+   (vertical-bar   (doom-darken base1 0.5))
+   (selection      dark-blue)
+   (builtin        blue)
+   (comments       base5)
+   (doc-comments   teal)
+   (constants      blue)
+   (functions      blue)
+   (keywords       green)
+   (methods        cyan)
+   (operators      orange)
+   (type           yellow)
+   (strings        green)
+   (variables      fg)
+   (numbers        violet)
+   (region         base0)
+   (error          red)
+   (warning        yellow)
+   (success        green)
+   (vc-modified    blue)
+   (vc-added       "#119e44")
+   (vc-deleted     red)
+
+   ;; custom categories
+   (hidden     `(,(car bg) "black" "black"))
+   (-modeline-bright doom-solarized-dark-high-contrast-brighter-modeline)
+   (-modeline-pad
+    (when doom-solarized-dark-high-contrast-padded-modeline
+      (if (integerp doom-solarized-dark-high-contrast-padded-modeline) doom-solarized-dark-high-contrast-padded-modeline 4)))
+
+   (modeline-fg     nil)
+   (modeline-fg-alt base5)
+
+   (modeline-bg
+    (if -modeline-bright
+        base3
+      `(,(doom-darken (car bg) 0.15) ,@(cdr base0))))
+   (modeline-bg-l
+    (if -modeline-bright
+        base3
+      `(,(doom-darken (car bg) 0.1) ,@(cdr base0))))
+   (modeline-bg-inactive   (doom-darken bg 0.1))
+   (modeline-bg-inactive-l `(,(car bg) ,@(cdr base1))))
+
+  ;; --- extra faces ------------------------
+  ((company-tooltip-selection     :background dark-cyan)
+   (elscreen-tab-other-screen-face :background "#353a42" :foreground "#1e2022")
+
+   ((line-number &override) :foreground base4)
+   ((line-number-current-line &override) :foreground fg)
+
+   (helm-selection :inherit 'bold
+                   :background selection
+                   :distant-foreground bg
+                   :extend t)
+
+   (font-lock-comment-face
+    :slant 'italic
+    :foreground comments
+    :background (if doom-solarized-dark-high-contrast-comment-bg (doom-lighten bg 0.05)))
+   (font-lock-doc-face
+    :inherit 'font-lock-comment-face
+    :foreground doc-comments)
+   (font-lock-keyword-face
+    :weight 'bold
+    :foreground keywords)
+   (font-lock-constant-face
+    :weight 'bold
+    :foreground constants)
+   ((font-lock-type-face &override) :slant 'italic)
+   ((font-lock-builtin-face &override) :slant 'italic)
+
+   ;;;; Centaur tabs
+   (centaur-tabs-active-bar-face :background blue)
+   (centaur-tabs-modified-marker-selected :inherit 'centaur-tabs-selected
+                                          :foreground blue)
+   (centaur-tabs-modified-marker-unselected :inherit 'centaur-tabs-unselected
+                                            :foreground blue)
+   ;;;; Doom modeline
+   (doom-modeline-bar :background blue)
+
+   (mode-line
+    :background modeline-bg :foreground modeline-fg
+    :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg)))
+   (mode-line-inactive
+    :background modeline-bg-inactive :foreground modeline-fg-alt
+    :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg-inactive)))
+   (mode-line-emphasis
+    :foreground (if -modeline-bright base8 highlight))
+
+   (solaire-mode-line-face
+    :inherit 'mode-line
+    :background modeline-bg-l
+    :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg-l)))
+   (solaire-mode-line-inactive-face
+    :inherit 'mode-line-inactive
+    :background modeline-bg-inactive-l
+    :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg-inactive-l)))
+
+   (tooltip              :background bg-alt :foreground fg)
+   ;;; --- major-mode faces -------------------
+   ;;;; css-mode / scss-mode
+   (css-proprietary-property :foreground orange)
+   (css-property             :foreground green)
+   (css-selector             :foreground blue)
+
+   ;;;; markdown-mode
+   (markdown-markup-face :foreground base5)
+   (markdown-header-face :inherit 'bold :foreground violet)
+   (markdown-url-face    :foreground teal :weight 'normal)
+   (markdown-reference-face :foreground base6)
+   ((markdown-bold-face &override)   :foreground fg)
+   ((markdown-italic-face &override) :foreground fg-alt)
+
+   ;;;; outline (affects org-mode)
+   ((outline-1 &override) :foreground blue)
+   ((outline-2 &override) :foreground green)
+   ((outline-3 &override) :foreground teal)
+   ((outline-4 &override) :foreground (doom-darken blue 0.2))
+   ((outline-5 &override) :foreground (doom-darken green 0.2))
+   ((outline-6 &override) :foreground (doom-darken teal 0.2))
+   ((outline-7 &override) :foreground (doom-darken blue 0.4))
+   ((outline-8 &override) :foreground (doom-darken green 0.4))
+
+   ;;;; org-mode
+   ((org-block &override) :background base0)
+   ((org-block-begin-line &override) :foreground comments :background base0)
+   (org-hide :foreground hidden)
+   (solaire-org-hide-face :foreground hidden)
+
+   ;;;; rainbow-delimeters
+   (rainbow-delimiters-depth-1-face :foreground blue)
+   (rainbow-delimiters-depth-2-face :foreground yellow)
+   (rainbow-delimiters-depth-3-face :foreground orange)
+   (rainbow-delimiters-depth-4-face :foreground green)
+   (rainbow-delimiters-depth-5-face :foreground cyan)
+   (rainbow-delimiters-depth-6-face :foreground violet)
+
+   ;;;; git-gutter-fringe
+   (git-gutter-fr:modified :foreground vc-modified)
+
+   ;;;; eshell-git-prompt powerline theme
+   (eshell-git-prompt-powerline-dir-face :background "steel blue" :foreground bg)
+   (eshell-git-prompt-powerline-clean-face :background "foreset green" :foreground bg)
+   (eshell-git-prompt-powerline-not-clean-face :background "indian red" :foreground bg)
+
+   ;;;; vterm
+   (vterm               :foreground fg)
+   (vterm-color-default :foreground fg)
+   (vterm-color-black   :background (doom-lighten base0 0.75)   :foreground base0)
+   (vterm-color-red     :background (doom-lighten red 0.75)     :foreground red)
+   (vterm-color-green   :background (doom-lighten green 0.75)   :foreground green)
+   (vterm-color-yellow  :background (doom-lighten yellow 0.75)  :foreground yellow)
+   (vterm-color-blue    :background (doom-lighten blue 0.75)    :foreground blue)
+   (vterm-color-magenta :background (doom-lighten magenta 0.75) :foreground magenta)
+   (vterm-color-cyan    :background (doom-lighten cyan 0.75)    :foreground cyan)
+   (vterm-color-white   :background (doom-lighten base8 0.75)   :foreground base8)
+   ))
+
+
+;;; doom-solarized-dark-high-contrast-theme.el ends here


### PR DESCRIPTION
New theme, doom-solarized-dark-high-contrast, based on existing doom-solarized-dark and solarized-dark-high-contrast-theme from https://github.com/bbatsov/solarized-emacs.

Screenshots:
![image](https://user-images.githubusercontent.com/24941170/108428602-cbd77080-720c-11eb-8917-a91ebcc642d6.png)
![image](https://user-images.githubusercontent.com/24941170/108428767-0fca7580-720d-11eb-9061-8a5e36de1e42.png)
![image](https://user-images.githubusercontent.com/24941170/108429104-8d8e8100-720d-11eb-8f29-180f52de74a8.png)

Let me know if you'd like any more!