### PR TITLE
Theme selectrum in doom-themes-base

### DIFF
--- a/doom-themes-base.el
+++ b/doom-themes-base.el
@@ -715,6 +715,17 @@
     ;;;; ivy-posframe
     (ivy-posframe :background (doom-darken bg-alt 0.2))
     (ivy-posframe-border :inherit 'internal-border)
+
+    ;;;; selectrum
+    (selectrum-current-candidate :background region :distant-foreground nil :extend t)
+    (selectrum-primary-highlight
+     :background nil
+     :foreground (doom-lighten grey 0.14)
+     :weight 'light)
+    (selectrum-secondary-highlight
+     :inherit 'selectrum-primary-highlight
+     :foreground magenta :background base1 :weight 'semi-bold)
+
     ;;;; jabber
     (jabber-activity-face          :foreground red   :weight 'bold)
     (jabber-activity-personal-face :foreground blue  :weight 'bold)


### PR DESCRIPTION
Supercedes https://github.com/hlissner/emacs-doom-themes/pull/569. Didn't realize I had included the new high contrast theme in the other PR. I don't want to remove it from my fork's master branch, so I've just opened this new PR from a different branch.
Edit: typo (wrong PR)