### PR TITLE
Remove theming for selectrum-*-highlight

### DIFF
--- a/doom-themes-base.el
+++ b/doom-themes-base.el
@@ -718,13 +718,6 @@
 
     ;;;; selectrum
     (selectrum-current-candidate :background region :distant-foreground nil :extend t)
-    (selectrum-primary-highlight
-     :background nil
-     :foreground (doom-lighten grey 0.14)
-     :weight 'light)
-    (selectrum-secondary-highlight
-     :inherit 'selectrum-primary-highlight
-     :foreground magenta :background base1 :weight 'semi-bold)
 
     ;;;; jabber
     (jabber-activity-face          :foreground red   :weight 'bold)


### PR DESCRIPTION
Fixes https://github.com/hlissner/emacs-doom-themes/issues/573 and will be forwards-compatible once https://github.com/raxod502/selectrum/issues/364 is resolved.

![Screenshot from 2021-02-24 15-57-18](https://user-images.githubusercontent.com/24941170/109065314-632f3e80-76b9-11eb-90a8-b1f3e1e092cc.png)
