### PR TITLE
Fix faces for doom-plain and doom-ephemeral themes

### DIFF
--- a/themes/doom-ephemeral-theme.el
+++ b/themes/doom-ephemeral-theme.el
@@ -262,6 +262,9 @@
 
    ;; rjsx
    (rjsx-tag :foreground magenta)
-  ))
+
+   ;; notmuch
+   (notmuch-wash-cited-text :foreground base6)
+   ))
 
 ;;; doom-ephemeral-theme.el ends here

--- a/themes/doom-plain-theme.el
+++ b/themes/doom-plain-theme.el
@@ -104,10 +104,12 @@ determine the exact padding."
    ;; Org
    (org-block-begin-line
     :foreground base5
+    :background bg-alt
     :extend t)
 
    (org-block-end-line
     :foreground base5
+    :background bg-alt
     :extend t)
 
    (org-block

--- a/themes/doom-plain-theme.el
+++ b/themes/doom-plain-theme.el
@@ -101,13 +101,18 @@ determine the exact padding."
    (hl-line
     :background base8)
 
+   ;; Org
    (org-block-begin-line
-    :foreground base2
-    :background base3)
+    :foreground base5
+    :extend t)
 
    (org-block-end-line
-    :foreground base2
-    :background base3)
+    :foreground base5
+    :extend t)
+
+   (org-block
+    :background bg-alt
+    :extend t)
 
    (org-level-1
     :slant 'italic
@@ -124,11 +129,9 @@ determine the exact padding."
     :foreground base2
     :background nil)
 
-   (org-level-3
-    :slant 'italic
-    :foreground base2
-    :background nil)
-
+   ;; Ivy
+   (ivy-posframe
+    :background bg-alt)
 
    ;; Font lock
    (font-lock-comment-face

--- a/themes/doom-plain-theme.el
+++ b/themes/doom-plain-theme.el
@@ -104,12 +104,10 @@ determine the exact padding."
    ;; Org
    (org-block-begin-line
     :foreground base5
-    :background bg-alt
     :extend t)
 
    (org-block-end-line
     :foreground base5
-    :background bg-alt
     :extend t)
 
    (org-block


### PR DESCRIPTION
Fixes face issues for doom ephemeral where mailing lists in notmuch have illegible font colour, and fixes ivy frame in doom-plain and org-src blocks.

Relevant screenshots:

Before:
![2021-02-21-091329_727x360_scrot](https://user-images.githubusercontent.com/53148859/111067264-834c6380-84e9-11eb-9c03-9dd0d411b5fa.png)
![2021-02-21-094226_878x549_scrot](https://user-images.githubusercontent.com/53148859/111067281-8fd0bc00-84e9-11eb-9eb9-3d7673cbbc7e.png)
![2021-02-21-092838_607x160_scrot](https://user-images.githubusercontent.com/53148859/111067287-995a2400-84e9-11eb-8ee3-4b269dc630d1.png)

After:
![2021-02-21-091203_681x332_scrot](https://user-images.githubusercontent.com/53148859/111067301-a70fa980-84e9-11eb-8e31-6f146062de7e.png)
![2021-02-21-094559_831x477_scrot](https://user-images.githubusercontent.com/53148859/111067306-ad058a80-84e9-11eb-9b7c-36ba267026b6.png)
![2021-02-21-094014_899x153_scrot](https://user-images.githubusercontent.com/53148859/111067309-b262d500-84e9-11eb-973a-b3180324fd00.png)

Sorry for the commit mess, I was learning git and magit usage while creating this PR, hope it isn't a problem.
