### PR TITLE
gruvbox-dark: make it closer to the orignal plus solaire mode fixes

### DIFF
--- a/themes/doom-gruvbox-theme.el
+++ b/themes/doom-gruvbox-theme.el
@@ -36,9 +36,9 @@ background contrast. All other values default to \"medium\"."
           ((equal doom-gruvbox-dark-variant "soft") '("#32302f" "#323232" nil))   ; bg0_s
           (t                                        '("#282828" "#282828" nil)))) ; bg0
    (bg-alt
-    (cond ((equal doom-gruvbox-dark-variant "hard") '("#282828" "#282828" nil))
-          ((equal doom-gruvbox-dark-variant "soft") '("#403d3d" "#404040" nil))
-          (t                                        '("#32302f" "#323232" nil))))
+    (cond ((equal doom-gruvbox-dark-variant "hard") '("#0d1011" "black" nil))     ; (self-defined)
+          ((equal doom-gruvbox-dark-variant "soft") '("#282828" "#282828" nil))   ; bg0
+          (t                                        '("#1d2021" "#1e1e1e" nil)))) ; bg_h
    (bg-alt2    '("#504945" "#504945" "brown"      )) ; bg2 (for region, selection etc.)
 
    (base0      '("#0d1011" "black"   "black"      )) ; (self-defined)
@@ -54,19 +54,20 @@ background contrast. All other values default to \"medium\"."
    (fg-alt     '("#d5c4a1" "#cccccc" "brightwhite")) ; fg2
 
    ;; Standardized official colours from gruvbox
-   (grey       '("#928374" "#909090" "brightblack"))   ; gray
-   (red        '("#fb4934" "#e74c3c" "red"))           ; bright-red
-   (magenta    '("#cc241d" "#cc241d" "magenta"))       ; red
-   (violet     '("#d3869b" "#d3869b" "brightmagenta")) ; bright-purple
-   (orange     '("#fe8019" "#fd971f" "orange"))        ; bright-orange
-   (yellow     '("#fabd2f" "#fabd2f" "yellow"))        ; bright-yellow
-   (teal       '("#8ec07c" "#8ec07c" "green"))         ; bright-aqua
-   (green      '("#b8bb26" "#b8bb26" "green"))         ; bright-green
-   (dark-green '("#98971a" "#98971a" "green"))         ; green
-   (blue       '("#83a598" "#83a598" "brightblue"))    ; bright-blue
-   (dark-blue  '("#458588" "#458588" "blue"))          ; blue
-   (cyan       '("#8ec07c" "#8ec07c" "brightcyan"))    ; bright-aqua
-   (dark-cyan  '("#689d6a" "#689d6a" "cyan"))          ; aqua
+   (grey        '("#928374" "#909090" "brightblack"))   ; gray
+   (red         '("#fb4934" "#e74c3c" "red"))           ; bright-red
+   (magenta     '("#cc241d" "#cc241d" "magenta"))       ; red
+   (violet      '("#d3869b" "#d3869b" "brightmagenta")) ; bright-purple
+   (orange      '("#fe8019" "#fd971f" "orange"))        ; bright-orange
+   (yellow      '("#fabd2f" "#fabd2f" "yellow"))        ; bright-yellow
+   (dark-yellow '("#d79921" "#fabd2f" "yellow"))        ; yellow
+   (teal        '("#8ec07c" "#8ec07c" "green"))         ; bright-aqua
+   (green       '("#b8bb26" "#b8bb26" "green"))         ; bright-green
+   (dark-green  '("#98971a" "#98971a" "green"))         ; green
+   (blue        '("#83a598" "#83a598" "brightblue"))    ; bright-blue
+   (dark-blue   '("#458588" "#458588" "blue"))          ; blue
+   (cyan        '("#8ec07c" "#8ec07c" "brightcyan"))    ; bright-aqua
+   (dark-cyan   '("#689d6a" "#689d6a" "cyan"))          ; aqua
 
    ;; face categories
    (highlight      yellow)
@@ -76,20 +77,20 @@ background contrast. All other values default to \"medium\"."
    (comments       (if doom-gruvbox-brighter-comments magenta grey))
    (doc-comments   (if doom-gruvbox-brighter-comments (doom-lighten magenta 0.2) (doom-lighten fg-alt 0.25)))
    (constants      violet)
-   (functions      cyan)
+   (functions      green)
    (keywords       red)
-   (methods        cyan)
-   (operators      cyan)
+   (methods        green)
+   (operators      fg)
    (type           yellow)
    (strings        green)
-   (variables      cyan)
+   (variables      blue)
    (numbers        violet)
    (region         bg-alt2)
    (error          red)
    (warning        yellow)
    (success        green)
 
-   (vc-modified    (doom-darken blue 0.15))
+   (vc-modified    (doom-darken cyan 0.15))
    (vc-added       (doom-darken green 0.15))
    (vc-deleted     (doom-darken red 0.15))
 
@@ -106,9 +107,9 @@ background contrast. All other values default to \"medium\"."
   (
    ;;;;;;;; Editor ;;;;;;;;
    (cursor :background "white")
-   (hl-line :background bg-alt)
+   (hl-line :background base3)
    ((line-number &override) :foreground base5)
-   ((line-number-current-line &override) :background bg-alt2 :foreground fg :bold t)
+   ((line-number-current-line &override) :background base3 :foreground yellow)
 
    ;; Vimish-fold
    ((vimish-fold-overlay &override) :inherit 'font-lock-comment-face :background bg-alt2 :weight 'light)
@@ -136,6 +137,10 @@ background contrast. All other values default to \"medium\"."
    (doom-modeline-bar :background dark-green)
    (doom-modeline-panel :background dark-green :foreground fg)
 
+   ;; Solaire
+   (solaire-mode-line-face :inherit 'mode-line)
+   (solaire-mode-line-inactive-face :inherit 'mode-line-inactive)
+
    ;;;;;;;; Search ;;;;;;;;
    ;; /find
    (isearch :foreground base0 :background orange)
@@ -149,7 +154,6 @@ background contrast. All other values default to \"medium\"."
 
    ;;;;;;;; Mini-buffers ;;;;;;;;
    (minibuffer-prompt :foreground cyan)
-   (solaire-hl-line-face :background bg-alt2)
 
    ;; ivy
    (ivy-current-match :background bg-alt2)
@@ -165,7 +169,7 @@ background contrast. All other values default to \"medium\"."
    (swiper-line-face :background bg-alt2)
 
    ;; ivy-posframe
-   (ivy-posframe :background bg-alt)
+   (ivy-posframe :background base3)
    (ivy-posframe-border :background base1)
 
    ;; neotree
@@ -185,13 +189,10 @@ background contrast. All other values default to \"medium\"."
 
    ;;;;;;;; Brackets ;;;;;;;;
    ;; Rainbow-delimiters
-   (rainbow-delimiters-depth-1-face :foreground red)
-   (rainbow-delimiters-depth-2-face :foreground yellow)
-   (rainbow-delimiters-depth-3-face :foreground cyan)
-   (rainbow-delimiters-depth-4-face :foreground red)
-   (rainbow-delimiters-depth-5-face :foreground yellow)
-   (rainbow-delimiters-depth-6-face :foreground cyan)
-   (rainbow-delimiters-depth-7-face :foreground red)
+   (rainbow-delimiters-depth-1-face :foreground orange)
+   (rainbow-delimiters-depth-2-face :foreground red)
+   (rainbow-delimiters-depth-3-face :foreground magenta)
+   (rainbow-delimiters-depth-4-face :foreground blue)
    ;; Bracket pairing
    ((show-paren-match &override) :foreground nil :background base5 :bold t)
    ((show-paren-mismatch &override) :foreground nil :background "red")
@@ -208,7 +209,7 @@ background contrast. All other values default to \"medium\"."
    (company-tooltip-common-selection :foreground cyan)
    (company-tooltip-annotation :foreground cyan)
    (company-tooltip-annotation-selection :foreground cyan)
-   (company-scrollbar-bg :background bg-alt)
+   (company-scrollbar-bg :background base3)
    (company-scrollbar-fg :background cyan)
    (company-tooltip-selection :background bg-alt2)
    (company-tooltip-mouse :background bg-alt2 :foreground nil)
@@ -230,17 +231,17 @@ background contrast. All other values default to \"medium\"."
    ;; flycheck
    (flycheck-error   :underline `(:style wave :color ,red)    :background base3)
    (flycheck-warning :underline `(:style wave :color ,yellow) :background base3)
-   (flycheck-info    :underline `(:style wave :color ,cyan)  :background base3)
+   (flycheck-info    :underline `(:style wave :color ,blue)   :background base3)
 
    ;; helm
    (helm-swoop-target-line-face :foreground magenta :inverse-video t)
 
    ;; magit
-   (magit-section-heading             :foreground yellow :weight 'bold)
-   (magit-branch-current              :underline cyan :inherit 'magit-branch-local)
+   (magit-section-heading             :foreground cyan :weight 'bold)
+   (magit-branch-current              :underline green :inherit 'magit-branch-local)
    (magit-diff-hunk-heading           :background base3 :foreground fg-alt)
    (magit-diff-hunk-heading-highlight :background bg-alt2 :foreground fg)
-   (magit-diff-context                :foreground bg-alt :foreground fg-alt)
+   (magit-diff-context                :foreground base3 :foreground fg-alt)
 
 
    ;;;;;;;; Major mode faces ;;;;;;;;
@@ -260,20 +261,25 @@ background contrast. All other values default to \"medium\"."
    (font-latex-math-face :foreground dark-cyan)
 
    ;; markdown-mode
-   (markdown-blockquote-face :inherit 'italic :foreground cyan)
-   (markdown-list-face :foreground red)
-   (markdown-url-face :foreground red)
+   (markdown-header-face :inherit 'bold :foreground green)
+   (markdown-header-delimiter-face :foreground orange)
+   (markdown-blockquote-face :inherit 'italic :foreground grey)
+   (markdown-list-face :foreground grey)
+   (markdown-url-face :foreground violet)
    (markdown-pre-face  :foreground cyan)
-   (markdown-link-face :inherit 'bold :foreground cyan)
+   (markdown-link-face :inherit 'underline :foreground grey)
    ((markdown-code-face &override) :background (doom-lighten base2 0.045))
 
    ;; mu4e-view
    (mu4e-header-key-face :foreground red)
 
    ;; org-mode
-   ((outline-1 &override) :foreground yellow)
-   ((outline-2 &override) :foreground cyan)
-   ((outline-3 &override) :foreground magenta)
+   ((outline-1 &override) :foreground green)
+   ((outline-2 &override) :foreground green)
+   ((outline-3 &override) :foreground yellow)
+   ((outline-4 &override) :foreground yellow)
+   ((outline-5 &override) :foreground dark-yellow)
+   ((outline-6 &override) :foreground dark-yellow)
    (org-ellipsis :underline nil :foreground orange)
    (org-tag :foreground yellow :bold nil)
    ((org-quote &override) :inherit 'italic :foreground base7 :background org-quote)


### PR DESCRIPTION
# Purpose
The current doom-gruvbox theme has  numerous deviations from the original theme which ends up making it look different from each other. This PR aims to make gruvbox look more closer to the original theme by using the [same choice of colors](https://github.com/morhetz/gruvbox/blob/master/colors/gruvbox.vim) where applicable.

This also includes some changes to make gruvbox look better with Solaire mode enabled.

# Summary of the changes made
- use the same colors as upstream where applicable
- make `bg-alt` darker than `bg`
- set modeline colors for solaire mode

# Screenshots
## Markdown
### Vim (original)
<img width="1046" alt="vim-markdown" src="https://user-images.githubusercontent.com/7343721/111206759-22697c00-860c-11eb-98a0-c7b815dc8fc8.png">

### Emacs (before)
<img width="1056" alt="emacs-markdown-before" src="https://user-images.githubusercontent.com/7343721/111206815-38773c80-860c-11eb-9fdd-aba381210b1b.png">

### Emacs (after)
<img width="1056" alt="emacs-markdown-after" src="https://user-images.githubusercontent.com/7343721/111206843-42993b00-860c-11eb-8c3a-ef3f2ca3b1ef.png">

## Emacs Lisp
### Vim (original)
<img width="1046" alt="lisp-vim" src="https://user-images.githubusercontent.com/7343721/111206867-4dec6680-860c-11eb-81bf-927dd5c60c9b.png">

### Emacs (before)
<img width="1056" alt="lisp-emacs-before" src="https://user-images.githubusercontent.com/7343721/111206905-593f9200-860c-11eb-82fc-0bc5ed412c16.png">

### Emacs (after)
<img width="1056" alt="lisp-emacs-after" src="https://user-images.githubusercontent.com/7343721/111206942-665c8100-860c-11eb-9b21-49eeaca45836.png">

