### PR TITLE
gruvbox-light: lsp symbol highlight bold, no background

### DIFF
--- a/themes/doom-gruvbox-light-theme.el
+++ b/themes/doom-gruvbox-light-theme.el
@@ -447,7 +447,7 @@ background contrast. All other values default to \"medium\"."
 
    ;; lsp
    (lsp-ui-doc-background      :background base2)
-   (lsp-face-highlight-read    :background (doom-blend bg orange 0.5))
+   (lsp-face-highlight-read    :background nil :weight 'bold)
    (lsp-face-highlight-textual :inherit 'lsp-face-highlight-read)
    (lsp-face-highlight-write   :inherit 'lsp-face-highlight-read)
 


### PR DESCRIPTION
lsp enables symbol highlighting by default.  In the doom-gruvbox-light theme, the highlight color makes the text harder to read as there is insufficient contrast.  

In the doom-gruvbox-theme the `lsp-face-highlight-read` defines a background color as the highlight, using `(doom-blend bg orange 0.5)`.  
The `lsp-face-highlight-textual` inherits from `lsp-face-highlight-read` and is used to highlight symbols by lsp

The change removes the background color from `lsp-face-highlight-read` and adds a bold weight to that face

Original theme
![doom-gruvbox-light-orange](https://user-images.githubusercontent.com/250870/111660615-2b25a200-8806-11eb-875e-392ef888d0ea.png)

Proposed change
![doom-gruvbox-light-bold](https://user-images.githubusercontent.com/250870/111660041-9fac1100-8805-11eb-8cd2-fdc883e44579.png)
