### PR TITLE
dracula-theme: Fix rendering of variable color

### DIFF
--- a/themes/doom-dracula-theme.el
+++ b/themes/doom-dracula-theme.el
@@ -80,7 +80,7 @@ determine the exact padding."
    (operators      violet)
    (type           violet)
    (strings        yellow)
-   (variables      (doom-lighten 'magenta 0.6))
+   (variables      (doom-lighten magenta 0.6))
    (numbers        violet)
    (region         base3)
    (error          red)


### PR DESCRIPTION
The value passed to `doom-lighten` function was incorrectly passed as variable reference `'magenta` instead of `magenta`.

This caused the color for `variables` to not render during startup but for some reason it worked if you did a `reload-theme (SPC h r t)`. See issue #572.

I have tested that this works in my fork.