### PR TITLE
doom-horizon: make line-number-current-line closer to the original

### DIFF
--- a/themes/doom-horizon-theme.el
+++ b/themes/doom-horizon-theme.el
@@ -67,6 +67,7 @@
     (hor-highlight  (doom-lighten base3 0.05))
     (hor-highlight-selected (doom-lighten base3 0.1))
     (hor-highlight-bright (doom-lighten base3 0.2))
+    (hor-highlight-brighter (doom-lighten base3 0.5))
 
     ;; face categories -- required for all themes
     (highlight      red)
@@ -121,7 +122,7 @@
 
     ;; ((line-number &override) :foreground (doom-lighten bg 0.05))
     ((line-number &override) :foreground hor-highlight-selected)
-    ((line-number-current-line &override) :foreground hor-highlight-bright)
+    ((line-number-current-line &override) :foreground hor-highlight-brighter)
 
     (font-lock-comment-face
       :inherit 'italic


### PR DESCRIPTION
Make it closer to the original theme and improve aesthetic.

On the left is Horizon on Visual Studio Code, the upper right is on Emacs, before, the lower one is also Emacs, but after brightening.
(Notice current line on each).

![image](https://user-images.githubusercontent.com/32123754/118758070-83c1fb80-b898-11eb-93bd-c2a10e7da5c4.png)



