### PR TITLE
Add new theme: Monokai Pro Machine Theme!

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ DOOM Themes is an opinionated UI plugin and pack of themes extracted from my
   - [X] `doom-miramare`: a port of [Franbach's][franbach] [Miramare][miramare], a variant of gruvbox theme (thanks to [sagittaros])
   - [X] `doom-molokai`: a theme based on Texmate's Monokai
   - [X] `doom-monokai-classic`: port of [Monokai]'s Classic variant (thanks to [ema2159])
-  - [X] `doom-monokai-pro`: port of [Monokai]'s Pro variant (thanks to [kadenbarlow]) 
+  - [X] `doom-monokai-machine`: port of [Monokai]'s Machine variant (thanks to [ianpan870102])
+  - [X] `doom-monokai-pro`: port of [Monokai]'s Pro variant (thanks to [kadenbarlow])
   - [X] `doom-moonlight` ported from VS Code's [Moonlight Theme] (thanks to [Brettm12345])
   - [X] `doom-nord`: dark variant of [Nord][nord] (thanks to [fuxialexander])
   - [X] `doom-nord-light`: light variant of [Nord][nord] (thanks to [fuxialexander])
@@ -70,7 +71,7 @@ DOOM Themes is an opinionated UI plugin and pack of themes extracted from my
   - [X] `doom-spacegrey`: [I'm sure you've heard of it][spacegrey] (thanks to [teesloane])
   - [x] `doom-tomorrow-day`: [Tomorrow][tomorrow]'s light variant (thanks to [emacswatcher])
   - [X] `doom-tomorrow-night`: one of the dark variants of [Tomorrow][tomorrow] (thanks to [emacswatcher])
-  - [X] `doom-wilmersdorf`: port of Ian Pan's [Wilmersdorf] (thanks to [ema2159])
+  - [X] `doom-wilmersdorf`: port of [Ian Pan]'s [Wilmersdorf] (thanks to [ema2159])
   - [X] `doom-zenburn`: port of the popular [Zenburn] theme (thanks to [jsoa])
   - [ ] `doom-mono-dark` / `doom-mono-light`: a minimalistic, monochromatic theme
   - [ ] `doom-tron`: based on Tron Legacy from [daylerees' themes][daylerees]
@@ -117,7 +118,7 @@ A list of themes which are usable, yet may need some minor adjustments.
     out [my mode-line configuration][mode-line] in my [emacs.d].
 
 ## Themes customization
-There are several themes which have their own customization options. For example, `doom-dark+` default modeline color can be changed with the `doom-dark+-blue-modeline` custom variable, or you can switch between `doom-gruvbox-light` variants with the `doom-gruvbox-light-variant` custom variable. 
+There are several themes which have their own customization options. For example, `doom-dark+` default modeline color can be changed with the `doom-dark+-blue-modeline` custom variable, or you can switch between `doom-gruvbox-light` variants with the `doom-gruvbox-light-variant` custom variable.
 
 ## Install
 
@@ -157,13 +158,13 @@ Here is a example configuration for `doom-theme`:
 
   ;; Enable flashing mode-line on errors
   (doom-themes-visual-bell-config)
-  
+
   ;; Enable custom neotree theme (all-the-icons must be installed!)
   (doom-themes-neotree-config)
   ;; or for treemacs users
   (setq doom-themes-treemacs-theme "doom-colors") ; use the colorful treemacs theme
   (doom-themes-treemacs-config)
-  
+
   ;; Corrects (and improves) org-mode's native fontification.
   (doom-themes-org-config))
 ```
@@ -220,11 +221,13 @@ pointers. Additional theme and plugin support requests are welcome too.
 [flatwhite]: https://github.com/biletskyy/flatwhite-syntax
 [franbach]: https://github.com/franbach
 [fuxialexander]: https://github.com/fuxialexander
-[gagbo]: https://github.com/gagbo 
+[gagbo]: https://github.com/gagbo
 [gruvbox]: https://github.com/morhetz/gruvbox
 [henna]: https://github.com/httpsterio/vscode-henna
 [horizon]: https://github.com/jolaleye/horizon-theme-vscode
 [hlinum]: https://melpa.org/#/hlinum
+[ianpan870102]: https://github.com/ianpan870102
+[Ian Pan]: https://github.com/ianpan870102
 [issues]: https://github.com/hlissner/emacs-doom-themes/issues
 [Iosvkem]: https://github.com/neutaaaaan/iosvkem
 [juanwolf]: https://github.com/juanwolf
@@ -267,7 +270,7 @@ pointers. Additional theme and plugin support requests are welcome too.
 [ztlevi]: https://github.com/ztlevi
 [laserwave]: https://github.com/Jaredk3nt/laserwave
 [hyakt]: https://github.com/hyakt
-[rouge theme]: https://github.com/josefaidt/rouge-theme 
+[rouge theme]: https://github.com/josefaidt/rouge-theme
 [JordanFaust]: https://github.com/JordanFaust
 [Zenburn]: https://github.com/bbatsov/zenburn-emacs
 [eziam]: https://github.com/thblt/eziam-theme-emacs

--- a/themes/doom-monokai-machine-theme.el
+++ b/themes/doom-monokai-machine-theme.el
@@ -1,0 +1,200 @@
+;;; doom-monokai-machine-theme.el --- inspired by Monokai Pro (Filter Machine) -*- no-byte-compile: t; -*-
+(require 'doom-themes)
+
+;;
+(defgroup doom-monokai-machine-theme nil
+  "Options for doom-themes"
+  :group 'doom-themes)
+
+(defcustom doom-monokai-machine-brighter-modeline nil
+  "If non-nil, more vivid colors will be used to style the mode-line."
+  :group 'doom-monokai-machine-theme
+  :type 'boolean)
+
+(defcustom doom-monokai-machine-brighter-comments nil
+  "If non-nil, comments will be highlighted in more vivid colors."
+  :group 'doom-monokai-machine-theme
+  :type 'boolean)
+
+(defcustom doom-monokai-machine-comment-bg doom-monokai-machine-brighter-comments
+  "If non-nil, comments will have a subtle, darker background. Enhancing their
+legibility."
+  :group 'doom-monokai-machine-theme
+  :type 'boolean)
+
+(defcustom doom-monokai-machine-padded-modeline doom-themes-padded-modeline
+  "If non-nil, adds a 4px padding to the mode-line. Can be an integer to
+determine the exact padding."
+  :group 'doom-monokai-machine-theme
+  :type '(choice integer boolean))
+
+;;
+(def-doom-theme doom-monokai-machine
+  "A dark theme inspired by Atom One Dark"
+
+  ;; name        default   256       16
+  ((bg         '("#273136" nil       nil            ))
+   (bg-alt     '("#1d2528" nil       nil            ))
+   (base0      '("#1a2023" "#121212" "black"        ))
+   (base1      '("#1d2528" "#1c1c1c" "brightblack"  ))
+   (base2      '("#222f2c" "#262626" "brightblack"  ))
+   (base3      '("#374c4b" "#3a3a3a" "brightblack"  ))
+   (base4      '("#545f62" "#585858" "brightblack"  ))
+   (base5      '("#6b7678" "#585858" "brightblack"  ))
+   (base6      '("#929f9c" "#6c6c6c" "brightblack"  ))
+   (base7      '("#b2bfbc" "#8a8a8a" "brightblack"  ))
+   (base8      '("#d2dfdc" "#bcbcbc" "white"        ))
+   (fg         '("#f2fffc" "#ffffff" "brightwhite"  ))
+   (fg-alt     '("#d2dfdc" "#c6c6c6" "white"        ))
+
+   (grey       base4)
+   (red        '("#ff6d7e" "#ff0000" "red"          ))
+   (orange     '("#ffb270" "#ff7f50" "brightred"    ))
+   (green      '("#a2e578" "#90ee90" "green"        ))
+   (teal       '("#7cd5f1" "#40e0d0" "brightgreen"  ))
+   (yellow     '("#ffed72" "#f0e68c" "yellow"       ))
+   (violet     '("#baa0f8" "#9370db" "magenta"      ))
+   (blue       '("#7cd5f1" "#51afef" "brightblue"   ))
+   (dark-blue  blue)
+   (magenta    violet)
+   (cyan       blue)
+   (dark-cyan  blue)
+
+   ;; face categories -- required for all themes
+   (highlight      yellow)
+   (vertical-bar   (doom-darken base1 0.1))
+   (selection      base3)
+   (builtin        magenta)
+   (comments       (if doom-monokai-machine-brighter-comments dark-cyan base5))
+   (doc-comments   (doom-lighten (if doom-monokai-machine-brighter-comments dark-cyan base5) 0.25))
+   (constants      violet)
+   (functions      green)
+   (keywords       red)
+   (methods        green)
+   (operators      red)
+   (type           cyan)
+   (strings        yellow)
+   (variables      fg)
+   (numbers        violet)
+   (region         base3)
+   (error          red)
+   (warning        yellow)
+   (success        green)
+   (vc-modified    orange)
+   (vc-added       green)
+   (vc-deleted     red)
+
+   ;; custom categories
+   (hidden     `(,(car bg) "black" "black"))
+   (-modeline-bright doom-monokai-machine-brighter-modeline)
+   (-modeline-pad
+    (when doom-monokai-machine-padded-modeline
+      (if (integerp doom-monokai-machine-padded-modeline) doom-monokai-machine-padded-modeline 4)))
+
+   (modeline-fg     fg)
+   (modeline-fg-alt base5)
+
+   (modeline-bg
+    (if -modeline-bright
+        (doom-darken blue 0.475)
+      `(,(doom-darken (car bg-alt) 0.15) ,@(cdr base0))))
+   (modeline-bg-l
+    (if -modeline-bright
+        (doom-darken blue 0.45)
+      `(,(doom-darken (car bg-alt) 0.1) ,@(cdr base0))))
+   (modeline-bg-inactive   `(,(doom-darken (car bg-alt) 0.1) ,@(cdr bg-alt)))
+   (modeline-bg-inactive-l `(,(car bg-alt) ,@(cdr base1))))
+
+
+  ;; --- extra faces ------------------------
+  ((cursor :background fg)
+   (elscreen-tab-other-screen-face :background "#353a42" :foreground "#1e2022")
+
+   (evil-goggles-default-face :inherit 'region :background (doom-blend region bg 0.5))
+
+   ((line-number &override) :foreground base4)
+   ((line-number-current-line &override) :foreground fg)
+
+   (font-lock-comment-face
+    :foreground comments
+    :background (if doom-monokai-machine-comment-bg (doom-lighten bg 0.05)))
+   (font-lock-doc-face
+    :inherit 'font-lock-comment-face
+    :foreground doc-comments)
+
+   (mode-line
+    :background modeline-bg :foreground modeline-fg
+    :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg)))
+   (mode-line-inactive
+    :background modeline-bg-inactive :foreground modeline-fg-alt
+    :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg-inactive)))
+   (mode-line-emphasis
+    :foreground (if -modeline-bright base8 highlight))
+
+   (solaire-mode-line-face
+    :inherit 'mode-line
+    :background modeline-bg-l
+    :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg-l)))
+   (solaire-mode-line-inactive-face
+    :inherit 'mode-line-inactive
+    :background modeline-bg-inactive-l
+    :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg-inactive-l)))
+
+   ;; Doom modeline
+   (doom-modeline-bar :background (if -modeline-bright modeline-bg highlight))
+   (doom-modeline-buffer-file :inherit 'mode-line-buffer-id :weight 'bold)
+   (doom-modeline-buffer-path :inherit 'mode-line-emphasis :weight 'bold)
+   (doom-modeline-buffer-project-root :foreground green :weight 'bold)
+
+   ;; ivy-mode
+   (ivy-current-match :background base3 :distant-foreground base7 :weight 'normal)
+
+   ;; isearch
+   (match          :foreground yellow :background base5)
+   (isearch        :inherit 'match)
+   (lazy-highlight :inherit 'match)
+
+   ;; --- major-mode faces -------------------
+   ;; css-mode / scss-mode
+   (css-proprietary-property :foreground orange)
+   (css-property             :foreground green)
+   (css-selector             :foreground blue)
+
+   ;; LaTeX-mode
+   (font-latex-math-face :foreground green)
+
+   ;; markdown-mode
+   (markdown-markup-face :foreground base5)
+   (markdown-header-face :inherit 'bold :foreground red)
+   ((markdown-code-face &override) :background (doom-lighten base3 0.05))
+
+   ;; org-mode
+   (org-hide :foreground hidden)
+   (solaire-org-hide-face :foreground hidden)
+
+   ;; lsp-mode
+   (lsp-headerline-breadcrumb-separator-face :foreground green)
+
+   ;; tree-sitter
+   (tree-sitter-hl-face:method.call        :foreground green)
+   (tree-sitter-hl-face:function.call      :foreground green)
+   (tree-sitter-hl-face:type.builtin       :foreground blue)
+   (tree-sitter-hl-face:variable.parameter :foreground orange)
+   (tree-sitter-hl-face:variable.special   :foreground blue)
+   (tree-sitter-hl-face:punctuation        :foreground base6)
+   (tree-sitter-hl-face:tag        :foreground red)
+   (tree-sitter-hl-face:attribute        :foreground blue)
+
+   ;; highlight escape sequence
+   (hes-escape-backslash-face              :foreground violet)
+   (hes-escape-sequence-face               :foreground violet)
+
+   ;; rjsx
+   (rjsx-tag :foreground red)
+   (rjsx-attr :foreground orange))
+
+  ;; --- extra variables ---------------------
+  ()
+  )
+
+;;; doom-monokai-machine-theme.el ends here


### PR DESCRIPTION
<!-- A description of your PR here -->

This PR adds the Monokai Pro **Machine** variant, as can be seen here: https://monokai.pro/vscode

p.s. Click on the filter that says "Machine"

![image](https://user-images.githubusercontent.com/36686900/115442525-b13d6a00-a244-11eb-8185-746562901e55.png)


Here are some side-by-side comparisons of this PR's doom-monokai-machine-theme and the officially supported Monokai Pro Machine in Visual Studio Code. IMHO, they are really quite identical ;-)

## My port in Emacs (doom-monokai-machine-theme)

![image](https://user-images.githubusercontent.com/36686900/115441764-cebe0400-a243-11eb-998e-766f87945776.png)

![image](https://user-images.githubusercontent.com/36686900/115441985-18a6ea00-a244-11eb-949b-d7801500b485.png)

## Official Monokai Pro Machine theme in Visual Studio Code

![image](https://user-images.githubusercontent.com/36686900/115441790-d8e00280-a243-11eb-85fe-a0b80a23ffc4.png)

![image](https://user-images.githubusercontent.com/36686900/115442072-2ceae700-a244-11eb-9692-ec269ac74338.png)


## Some more screenshots of doom-monokai-machine theme in action!

![image](https://user-images.githubusercontent.com/36686900/115442955-358fed00-a245-11eb-86a1-e2b0457159b5.png)

![image](https://user-images.githubusercontent.com/36686900/115443035-50626180-a245-11eb-8400-0891d7476414.png)

![image](https://user-images.githubusercontent.com/36686900/115443105-6cfe9980-a245-11eb-9499-17d8ba6e85ca.png)
