### PR TITLE
Add terraform-mode faces

### DIFF
--- a/doom-themes-base.el
+++ b/doom-themes-base.el
@@ -1212,6 +1212,9 @@
     (term-color-magenta :background magenta :foreground magenta)
     (term-color-cyan    :background cyan    :foreground cyan)
     (term-color-white   :background base8   :foreground base8)
+    ;;;; terraform-mode
+    (terraform--resource-type-face :foreground type)
+    (terraform--resource-name-face :foreground strings)
     ;;;; tldr
     (tldr-command-itself   :foreground bg :background green :weight 'semi-bold)
     (tldr-title            :foreground yellow :bold t :height 1.4)


### PR DESCRIPTION
Adds faces added by `terraform-mode` to `doom-themes-base.el`.

![terraform-mode](https://user-images.githubusercontent.com/453843/116894474-fc368480-ac29-11eb-858b-67f19a29a094.png)
