### PR TITLE
Adapt treemacs theme generation to all-the-icons#228

### DIFF
--- a/doom-themes-ext-treemacs.el
+++ b/doom-themes-ext-treemacs.el
@@ -94,39 +94,6 @@ variable-pitch face."
            'dired-mode-hook
            #'doom-themes-setup-tab-width))
 
-(defun doom-themes--get-treemacs-extensions (ext)
-  "Expand the extension pattern EXT into a list of extensions.
-
-This is used to generate extensions for `treemacs' from `all-the-icons-icon-alist'."
-  (let* ((subs '((".\\?" . "") ("\\?" . "") ("\\." . "")
-                 ("\\" . "") ("^" . "") ("$" . "")
-                 ("'" . "") ("*." . "") ("*" . "")))
-         (e (replace-regexp-in-string
-             (regexp-opt (mapcar 'car subs))
-             (lambda (it) (cdr (assoc-string it subs)))
-             ext t t))
-         (exts (list e)))
-    ;; Handle "[]"
-    (when-let* ((s (split-string e "\\[\\|\\]"))
-                (f (car s))
-                (m (cadr s))
-                (l (cadr (cdr s)))
-                (mcs (delete "" (split-string m ""))))
-      (setq exts nil)
-      (dolist (c mcs)
-        (push (concat f c l) exts)))
-    ;; Handle '?
-    (dolist (ext exts)
-      (when (string-match-p "?" ext)
-        (when-let ((s (split-string ext "?")))
-          (setq exts nil)
-          (push (string-join s "") exts)
-          (push (concat (if (> (length (car s)) 1)
-                            (substring (car s) 0 -1))
-                        (cadr s)) exts))))
-    exts))
-
-
 ;;
 ;;; Bootstrap
 
@@ -290,8 +257,8 @@ This is used to generate extensions for `treemacs' from `all-the-icons-icon-alis
          :icon (format "%s\t" (all-the-icons-octicon "book" :height 1.0 :v-adjust 0.0 :face 'all-the-icons-blue))
          :extensions (license))
 
-        (dolist (item all-the-icons-icon-alist)
-          (let* ((extensions (doom-themes--get-treemacs-extensions (car item)))
+        (dolist (item all-the-icons-extension-icon-alist)
+          (let* ((extension (car item))
                  (func (cadr item))
                  (args (append (list (cadr (cdr item))) '(:v-adjust -0.05 :height 0.85) (cdr (cddr item))))
                  (icon (apply func args)))
@@ -300,9 +267,8 @@ This is used to generate extensions for `treemacs' from `all-the-icons-icon-alis
                    (tui-icons (treemacs-theme->tui-icons treemacs--current-theme))
                    (gui-icon  (car icon-pair))
                    (tui-icon  (cdr icon-pair)))
-              (--each extensions
-                (ht-set! gui-icons it gui-icon)
-                (ht-set! tui-icons it tui-icon)))))
+              (ht-set! gui-icons extension gui-icon)
+              (ht-set! tui-icons extension tui-icon))))
 
         ;; File extensions for whom the above did not work (likely because their
         ;; regexp is too complicated to be reversed with


### PR DESCRIPTION
https://github.com/domtronn/all-the-icons.el/pull/228 separates a large portion of extension-handling regexes to a separate extension list. This PR removes references to the to-be variable all-the-icons-icon-alist.
And coincidently simplifies some of doom-themes' code by removing `doom-themes--get-treemacs-extensions`!