### PR TITLE
Resolved issue where breadcrumb separators do not appear

### DIFF
--- a/themes/doom-one-light-theme.el
+++ b/themes/doom-one-light-theme.el
@@ -191,6 +191,7 @@ determine the exact padding."
    (lsp-face-highlight-read    :background (doom-blend red bg 0.3))
    (lsp-face-highlight-textual :inherit 'lsp-face-highlight-read)
    (lsp-face-highlight-write   :inherit 'lsp-face-highlight-read)
+   (lsp-headerline-breadcrumb-separator-face :foreground green)
    )
 
   ;; --- extra variables ---------------------


### PR DESCRIPTION
Set lsp-headerline-breadcrumb-separator-face foreground to green to resolve issue where separates do not appear for lsp-headerline-breadcrumb-mode for doom-one-light theme.

**Before**
<img width="378" alt="Screen Shot 2021-05-19 at 11 01 22 pm" src="https://user-images.githubusercontent.com/22571513/118836173-38d6d100-b8f6-11eb-9fda-a6ae1dc27ed5.png">

**After**
<img width="449" alt="Screen Shot 2021-05-19 at 10 57 43 pm" src="https://user-images.githubusercontent.com/22571513/118836300-4db36480-b8f6-11eb-9bb6-9f003c4db210.png">
