### PR TITLE
molokai & monokai-classic : set vc-modified to cyan after 3f09923

### DIFF
--- a/themes/doom-molokai-theme.el
+++ b/themes/doom-molokai-theme.el
@@ -110,7 +110,7 @@ Can be an integer to determine the exact padding."
    (error          red)
    (warning        yellow)
    (success        green)
-   (vc-modified    base4)
+   (vc-modified    cyan)
    (vc-added       (doom-darken green 0.15))
    (vc-deleted     red)
 

--- a/themes/doom-monokai-classic-theme.el
+++ b/themes/doom-monokai-classic-theme.el
@@ -75,7 +75,7 @@ determine the exact padding."
    (error          red)
    (warning        yellow)
    (success        green)
-   (vc-modified    base4)
+   (vc-modified    cyan)
    (vc-added       (doom-darken green 0.15))
    (vc-deleted     red)
 


### PR DESCRIPTION
Very simple change, did not follow the template for that reason.

3f09923 forced git-gutter faces to follow vc-modified, but in a few themes, vc-modified was (mistakenly I guess) set to base4 (a kind of black), hence I am modifying vc-modified to cyan.

Feel free to ask any question.

Best,

Aymeric