### PR TITLE
doom-horizon: make comments' slant italic

### DIFF
--- a/themes/doom-horizon-theme.el
+++ b/themes/doom-horizon-theme.el
@@ -110,6 +110,7 @@
 
   ;;;; Base theme face overrides
   (((font-lock-comment-face &override)
+    :slant 'italic
     :background (if doom-horizon-comment-bg (doom-lighten bg 0.03)))
    (fringe :background bg)
    (link :foreground yellow :inherit 'underline)


### PR DESCRIPTION
Before: on the left, after: on the right
![image](https://user-images.githubusercontent.com/32123754/122017335-1304f500-cdec-11eb-9b84-448430a2c88d.png)

Original theme (referenced: [Horizon theme](https://horizontheme.netlify.app/) )
![image](https://horizontheme.netlify.app/js.f72b45a6.png)

Make comments italic, like the original.

Edit: removed the PR template.