### PR TITLE
Add vertico-current definition

### DIFF
--- a/doom-themes-base.el
+++ b/doom-themes-base.el
@@ -789,6 +789,8 @@
     (ivy-posframe-border :inherit 'internal-border)
     ;;;; selectrum
     (selectrum-current-candidate :background region :distant-foreground nil :extend t)
+    ;;;; vertico
+    (vertico-current :background region :distant-foreground nil :extend t)
     ;;;; jabber
     (jabber-activity-face          :foreground red   :weight 'bold)
     (jabber-activity-personal-face :foreground blue  :weight 'bold)

--- a/themes/doom-one-light-theme.el
+++ b/themes/doom-one-light-theme.el
@@ -185,6 +185,8 @@ Can be an integer to determine the exact padding."
    (ivy-posframe               :background base0)
    ;;;; selectrum
    (selectrum-current-candidate :background base1)
+   ;;;; vertico
+   (vertico-current :background base1)
    ;;;; solaire-mode
    (solaire-mode-line-face
     :inherit 'mode-line


### PR DESCRIPTION
This adds support for [vertico](https://github.com/minad/vertico); specifically highlighting the current selected candidate via the `vertico-current` face.

I simply copy-and-pasted the definitions for `selectrum`, which `vertico` is basically a drop-in replacement for.

The result, therefore, as with `selectrum`, is a more subtle highlighting:

![Screenshot from 2021-06-27 17-27-35](https://user-images.githubusercontent.com/1134/123559912-ff9f4580-d76c-11eb-80f1-daa632689c9b.png)

Before:

![Screenshot from 2021-06-27 17-30-27](https://user-images.githubusercontent.com/1134/123559999-8e13c700-d76d-11eb-9526-f5df79c098e3.png)

