### PR TITLE
[acario-dark] Fix modeline-bg when brighter

### DIFF
--- a/themes/doom-acario-dark-theme.el
+++ b/themes/doom-acario-dark-theme.el
@@ -101,7 +101,7 @@ determine the exact padding."
 
    (modeline-bg
     (if -modeline-bright
-        modeline-bg
+        (doom-blend blue bg 0.35)
       `(,(car base3) ,@(cdr base1))))
    (modeline-bg-l
     (if -modeline-bright

--- a/themes/doom-acario-light-theme.el
+++ b/themes/doom-acario-light-theme.el
@@ -103,7 +103,7 @@ determine the exact padding."
 
    (modeline-bg
     (if -modeline-dark
-        modeline-bg
+        (doom-blend blue bg 0.35)
       `(,(car base3) ,@(cdr base0))))
    (modeline-bg-l
     (if -modeline-dark


### PR DESCRIPTION
No screenshot because loading the theme simply errors if the bright modeline custom is set.
