### PR TITLE
org-block darkened as bg and base3 are very alike

### DIFF
--- a/themes/doom-vibrant-theme.el
+++ b/themes/doom-vibrant-theme.el
@@ -141,6 +141,7 @@ Can be an integer to determine the exact padding."
     :background modeline-bg-inactive :foreground modeline-fg-inactive
     :box (if -modeline-pad `(:line-width ,-modeline-pad :color ,modeline-bg-inactive)))
    (mode-line-emphasis :foreground (if doom-vibrant-brighter-modeline base8 highlight))
+   (org-block :background (doom-darken base3 0.1))
 
    ;;;; all-the-icons
    ((all-the-icons-dblue &override) :foreground dark-cyan)


### PR DESCRIPTION
Theme: doom-vibrant color `bg` and `base3` are very similar, leading to org-blocks being hard to distinguish from background.
`((bg         '("#242730" "black"       "black" ))`
`(base3      '("#23272e" "#262626"     "brightblack" ))`

Screenshot of before: Very hard to distinguish color `bg` from color `base3`

![doom-vibrant_before](https://user-images.githubusercontent.com/18187027/125508422-06e385cd-d2e9-4b1d-abbe-000bfe70e1e1.png)

Screenshot of after: Easier distinguish color `bg` from color `(doom-darken base3 0.1)`

![doom-vibrant_after](https://user-images.githubusercontent.com/18187027/125508432-eb75737e-60c8-44f2-aa83-aae012c91a59.png)