### PR TITLE
fix pdf-tools midnight-mode colors #338

### DIFF
--- a/doom-themes-base.el
+++ b/doom-themes-base.el
@@ -1456,7 +1456,7 @@
     ;;;; objed
     (objed-cursor-color (doom-color 'red))
     ;;;; pdf-tools
-    (pdf-view-midnight-colors `(cons ,(doom-color 'fg) ,(doom-color 'bg)))
+    (setq pdf-view-midnight-colors (cons (doom-color 'fg) (doom-color 'bg)))
     ;;;; vc <built-in>
     (vc-annotate-color-map
      `(list (cons 20  ,(doom-color 'green))


### PR DESCRIPTION
fixed midnight-mode colors in pdf-tools. Syntax seems to have changed and autodetection for doom-themes didn't work anymore. 
