### PR TITLE
Add marginalia file privilege faces

### DIFF
--- a/doom-themes-base.el
+++ b/doom-themes-base.el
@@ -932,6 +932,14 @@
     (markdown-html-entity-face        :inherit 'font-lock-variable-name-face)
     (markdown-html-tag-delimiter-face :inherit 'markdown-markup-face)
     (markdown-html-tag-name-face      :inherit 'font-lock-keyword-face)
+    ;;;; marginalia
+    (marginalia-file-priv-dir   :foreground blue)
+    (marginalia-file-priv-exec  :foreground green)
+    (marginalia-file-priv-link  :foreground violet)
+    (marginalia-file-priv-other :foreground magenta)
+    (marginalia-file-priv-rare  :foreground fg)
+    (marginalia-file-priv-read  :foreground yellow)
+    (marginalia-file-priv-write :foreground red)
     ;;;; message <built-in>
     (message-header-name       :foreground green)
     (message-header-subject    :foreground highlight :weight 'bold)


### PR DESCRIPTION
Now that https://github.com/minad/marginalia/pull/91 has been merged, Marginalia has new faces to do exactly the same thing a `diredfl` currently does with file attributes. I.e. this:

![image](https://user-images.githubusercontent.com/20903656/126977587-07e604be-fb94-4b20-bee8-2dd4dbf938bd.png)

So, here's a PR that just copies the `diredfl` face information, just for the incoming Marginalia faces.