### PR TITLE
Add orderless faces

### DIFF
--- a/doom-themes-base.el
+++ b/doom-themes-base.el
@@ -1044,6 +1044,11 @@
     ;;;; objed
     (objed-mode-line :inherit 'warning :weight 'bold)
     (objed-hl        :inherit 'region :background (doom-blend region bg 0.5))
+    ;;;; orderless
+    (orderless-match-face-0 :weight 'bold :foreground (doom-blend blue    fg 0.6) :background (doom-blend blue    bg 0.1))
+    (orderless-match-face-1 :weight 'bold :foreground (doom-blend magenta fg 0.6) :background (doom-blend magenta bg 0.1))
+    (orderless-match-face-2 :weight 'bold :foreground (doom-blend green   fg 0.6) :background (doom-blend green   bg 0.1))
+    (orderless-match-face-3 :weight 'bold :foreground (doom-blend yellow  fg 0.6) :background (doom-blend yellow  bg 0.1))
     ;;;; org <built-in> <modes:org-mode>
     (org-archived                 :foreground doc-comments)
     (org-block                    :background base3    :extend t)


### PR DESCRIPTION
This adds support for the four (orderless)[https://github.com/oantolin/orderless] faces, seen below

![image](https://user-images.githubusercontent.com/20903656/127002200-f0376356-e93c-4703-a457-232b9710cb8b.png)

Unfortunately, this patch makes my Emacs segfault, so I can't easily provide an after image. If anyone has any idea what's going on *please* let me know. Full error: http://ix.io/3u7E