### PR TITLE
Add marginalia documentation face

### DIFF
--- a/doom-themes-base.el
+++ b/doom-themes-base.el
@@ -933,6 +933,7 @@
     (markdown-html-tag-delimiter-face :inherit 'markdown-markup-face)
     (markdown-html-tag-name-face      :inherit 'font-lock-keyword-face)
     ;;;; marginalia
+    (marginalia-documentation   :inherit 'font-lock-doc-face)
     (marginalia-file-priv-dir   :foreground blue)
     (marginalia-file-priv-exec  :foreground green)
     (marginalia-file-priv-link  :foreground violet)


### PR DESCRIPTION
This defaults to `:inherit completions-annotations`, which is `(italic shadow)`. However, for *documentation* `font-lock-doc-face` would seem more sensible.

Default:

![image](https://user-images.githubusercontent.com/20903656/127025041-8d67c220-1c90-4053-afea-5adaa010e511.png)

With this patch:

![image](https://user-images.githubusercontent.com/20903656/127025084-7f509962-ad61-4756-9d7c-fad2c698c1dd.png)
