### PR TITLE
doom-horizon: better orderless face

### DIFF
--- a/themes/doom-horizon-theme.el
+++ b/themes/doom-horizon-theme.el
@@ -171,6 +171,8 @@
    (markdown-bold-face             :foreground violet)
    (markdown-table-face            :foreground fg :background base1)
    ((markdown-code-face &override) :foreground orange :background base1)
+   ;;;; orderless
+   (orderless-match-face-1 :weight 'bold :foreground (doom-blend red fg 0.6) :background (doom-blend red bg 0.1))
    ;;;; mic-paren
    (paren-face-match    :foreground green   :background base0 :weight 'ultra-bold)
    (paren-face-mismatch :foreground yellow :background base0   :weight 'ultra-bold)


### PR DESCRIPTION
change orderless-match-face-1 from magenta to red
---
The magenta stands out too little from the background imo.
Before:
![image](https://user-images.githubusercontent.com/19792685/128775129-c39ce2c1-9d00-4f4e-a3fe-da5cb3507199.png)
After:
![image](https://user-images.githubusercontent.com/19792685/128775095-87abab57-8c32-439c-b201-291070c9535c.png)


