### PR TITLE
Fix ayu-light line-number

### DIFF
--- a/themes/doom-ayu-light-theme.el
+++ b/themes/doom-ayu-light-theme.el
@@ -141,7 +141,7 @@ determine the exact padding."
    (modeline-bg-inactive-l `(,(car bg) ,@(cdr base1))))
 
   ;;;; Base theme face overrides
-  (((line-number &override) :foreground base4)
+  (((line-number &override) :foreground (doom-lighten fg 0.7))
    ((line-number-current-line &override) :foreground fg)
    ((font-lock-comment-face &override)
     :background (if doom-ayu-light-comment-bg (doom-lighten bg 0.05)))


### PR DESCRIPTION
As described in #659 (Screenshots also there):

Ayu-Light Variant has invisible line numbers, for some reason.
Just use a lighter variant of the foreground to fix that.
