### PR TITLE
3 for 1: Add org-cite faces, fade diredfl dash, marginalia numbers

### DIFF
--- a/doom-themes-base.el
+++ b/doom-themes-base.el
@@ -1071,6 +1071,8 @@
     (org-checkbox                 :inherit 'org-todo)
     (org-checkbox-statistics-done :inherit 'org-done)
     (org-checkbox-statistics-todo :inherit 'org-todo)
+    (org-cite                     :foreground (doom-blend teal fg 0.9))
+    (org-cite-key                 :foreground (doom-blend teal fg 0.6) :underline t)
     (org-code                     :inherit 'org-block :foreground orange)
     (org-date                     :foreground yellow)
     (org-default                  :inherit 'variable-pitch)

--- a/doom-themes-base.el
+++ b/doom-themes-base.el
@@ -941,6 +941,9 @@
     (marginalia-file-priv-rare  :foreground fg)
     (marginalia-file-priv-read  :foreground yellow)
     (marginalia-file-priv-write :foreground red)
+    (marginalia-number          :foreground numbers)
+    (marginalia-size            :foreground violet)
+    (marginalia-lighter         :foreground violet)
     ;;;; message <built-in>
     (message-header-name       :foreground green)
     (message-header-subject    :foreground highlight :weight 'bold)

--- a/doom-themes-base.el
+++ b/doom-themes-base.el
@@ -438,7 +438,7 @@
     (diredfl-flag-mark-line         :background (doom-blend yellow bg 0.1))
     (diredfl-ignored-file-name      :foreground comments)
     (diredfl-link-priv              :foreground violet)
-    (diredfl-no-priv                :foreground fg)
+    (diredfl-no-priv                :inherit 'shadow)
     (diredfl-number                 :foreground orange)
     (diredfl-other-priv             :foreground magenta)
     (diredfl-rare-priv              :foreground fg)


### PR DESCRIPTION
## 1/3 New Org-cite faces

![image](https://user-images.githubusercontent.com/20903656/133661632-8cbc2a9e-c2f3-4142-bf0a-f520a33317e6.png)
![image](https://user-images.githubusercontent.com/20903656/133661714-f23b8225-46f2-4e85-8180-baab0fcf5496.png)

## 2/3 Fade the diredfl dash

Before

![image](https://user-images.githubusercontent.com/20903656/133662249-2b0e3724-49bf-433f-acb1-c31b72805b16.png)

After

![image](https://user-images.githubusercontent.com/20903656/133662267-18d43f2e-7348-44a4-ad13-2dd647ef8504.png)

## 3/3 Marginalia numbers

Currently, `marginalia-numbers` inherits from `font-lock-constant-face`, but we have a colour for numbers! Marginalia though is over-eager with the inheriting from `marginali-numbers` though, so we set the list and size style to be unaffected, i.e. violet.

Before

![image](https://user-images.githubusercontent.com/20903656/133662753-32cbe2b6-4473-4ae4-9592-205b96111dea.png)

After

![image](https://user-images.githubusercontent.com/20903656/133662839-ac12df4d-fbf7-4461-b61b-32bb9405be46.png)
