### PR TITLE
fix(base): change corfu-background to corfu-default

### DIFF
--- a/doom-themes-base.el
+++ b/doom-themes-base.el
@@ -301,7 +301,7 @@
     ;;;; company-box
     (company-box-candidate :foreground fg)
     ;;;; corfu
-    (corfu-background :inherit 'tooltip)
+    (corfu-default :inherit 'tooltip)
     (corfu-current :background bg :foreground fg)
     ;;;; circe
     (circe-fool :foreground doc-comments)


### PR DESCRIPTION
In this [commit](https://github.com/minad/corfu/commit/b94d4f09552f90915503687ddb608326f4d85755), `corfu-background` was changed to `corfu-default`.