### PR TITLE
feat: add everforest themes

### DIFF
--- a/doom-everforest-hard-theme.el
+++ b/doom-everforest-hard-theme.el
@@ -1,4 +1,4 @@
-;;; doom-everforest-hard-theme.el --- a port of Sainnhe's everforest-hard theme; -*- lexical-binding: t; no-byte-compile: t; -*-
+;;; doom-everforest-hard-theme.el --- A port of Sainnhe's everforest-hard theme; -*- lexical-binding: t; no-byte-compile: t; -*-
 ;;
 ;; Author: Echinoidea <https://github.com/echinoidea>
 ;; Maintainer:
@@ -36,7 +36,7 @@ determine the exact padding."
 ;;; Theme definition
 
 (def-doom-theme doom-everforest-hard
-  "Green based color scheme; designed to be warm and soft."
+    "Green based color scheme; designed to be warm and soft."
 
   ;; name        gui       256       16
   ((bg         '("#1e2326" "#1e2326" nil          )) ; bg1

--- a/doom-everforest-medium-theme.el
+++ b/doom-everforest-medium-theme.el
@@ -1,4 +1,4 @@
-;;; doom-everforest-hard-theme.el --- a port of Sainnhe's everforest-hard theme; -*- lexical-binding: t; no-byte-compile: t; -*-
+;;; doom-everforest-hard-theme.el --- A port of Sainnhe's everforest-hard theme; -*- lexical-binding: t; no-byte-compile: t; -*-
 ;;
 ;; Author: Echinoidea <https://github.com/echinoidea>
 ;; Maintainer:
@@ -36,7 +36,7 @@ determine the exact padding."
 ;;; Theme definition
 
 (def-doom-theme doom-everforest-medium
-  "Green based color scheme; designed to be warm and soft."
+    "Green based color scheme; designed to be warm and soft."
 
   ;; name        gui       256       16
   ((bg         '("#232a2e" "#232a2e" nil          )) ; bg1

--- a/doom-everforest-soft-theme.el
+++ b/doom-everforest-soft-theme.el
@@ -1,4 +1,4 @@
-;;; doom-everforest-soft-theme.el --- a port of Sainnhe's everforest-hard theme; -*- lexical-binding: t; no-byte-compile: t; -*-
+;;; doom-everforest-soft-theme.el --- A port of Sainnhe's everforest-hard theme; -*- lexical-binding: t; no-byte-compile: t; -*-
 ;;
 ;; Author: Echinoidea <https://github.com/echinoidea>
 ;; Maintainer:
@@ -36,7 +36,7 @@ determine the exact padding."
 ;;; Theme definition
 
 (def-doom-theme doom-everforest-soft
-  "Green based color scheme; designed to be warm and soft."
+    "Green based color scheme; designed to be warm and soft."
 
   ;; name        gui       256       16
   ((bg         '("#293136" "#293136" nil          )) ; bg1


### PR DESCRIPTION
This PR adds three themes: doom-everforest-hard, doom-everforest-medium, and doom-everforest-soft.

I have not found any Everforest themes that work well with Doom emacs, particularly with packages like vterm. 

There was one issue some time ago that requested this, but nothing came of it. 
#808 

These theme files are based on doom-miramare-theme.el for no particular reason. The colors were taken from the official Everforest repository [https://github.com/sainnhe/everforest] and is credited in the file headers.

Everforest Soft
![everforest-soft](https://github.com/user-attachments/assets/603e3740-f205-4c16-b13f-bc0142c3503e)

Everforest Medium
![everforest-medium](https://github.com/user-attachments/assets/a5062bfd-8654-480e-b1cc-7ceb76b326c3)

Everforest Hard
![everforest-hard](https://github.com/user-attachments/assets/ffa6018a-4199-4c96-94f9-e8ed229d24bd)

Fix: #0000
Ref: #0000
Close: #0000

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [X] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [X] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [X] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.