### PR TITLE
fix(base): hide leading stars in solaire mode

### DIFF
--- a/doom-themes-base.el
+++ b/doom-themes-base.el
@@ -1349,7 +1349,7 @@
     ;;;; solaire-mode
     (solaire-default-face  :inherit 'default :background bg-alt)
     (solaire-hl-line-face  :inherit 'hl-line :background bg :extend t)
-    (solaire-org-hide      :inherit 'org-hide :foreground bg-alt)
+    (solaire-org-hide-face :inherit 'org-hide :foreground bg-alt)
     ;;;; spaceline
     (spaceline-highlight-face   :background highlight)
     (spaceline-modified         :background vc-modified)


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->
Fix a typo in doom-themes-base.el that has been causing me constant low-grade stress.

Before:
<img width="181" height="85" alt="2025-11-02_00-11-1762066888" src="https://github.com/user-attachments/assets/20129b7a-f624-4bfb-98e2-f0cba19ee79e" />
After:
<img width="195" height="86" alt="2025-11-02_00-11-1762066893" src="https://github.com/user-attachments/assets/0df0fca1-d499-48c2-87d7-fefac895481f" />

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it generally means we like the idea, but
     some more work must be done before it is merge ready.
   - If you decide to close your PR, please let us know why you did so.

-->
