### PR TITLE
fix(ext-org): indent after description list terms

### DIFF
--- a/extensions/doom-themes-ext-org.el
+++ b/extensions/doom-themes-ext-org.el
@@ -117,7 +117,7 @@ N is the match index."
                ;; make plain list bullets stand out.
                ;; give spaces before and after list bullet org-indent face to
                ;; keep correct indentation on mixed-pitch-mode
-               ("^\\( *\\)\\([-+]\\|\\(?:[0-9]+\\|[a-zA-Z]\\)[).]\\)\\([ \t]\\)"
+               ("^\\( *\\)\\([-+]\\(?:[ \t].*[ \t]::\\)?\\|\\(?:[0-9]+\\|[a-zA-Z]\\)[).]\\)\\([ \t]\\)"
                 ,@(if org-indent? '((1 'org-indent append)))
                 (2 'org-list-dt append)
                 ,@(if org-indent? '((3 'org-indent append)))))


### PR DESCRIPTION
Updated the list bullet regex in `doom-themes-enable-org-fontification` to match list items with description terms.

Before:
<img width="123" height="27" alt="before" src="https://github.com/user-attachments/assets/384b60ef-968e-447a-bfe6-7d282f350bc5" />

After:
<img width="134" height="30" alt="after" src="https://github.com/user-attachments/assets/0d6f26b3-e877-4136-bf6b-497f7ad73114" />

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.
