### PR TITLE
feat(dark+): add alternative faces for tab-bar and tab-line modes

### DIFF
--- a/themes/doom-dark+-theme.el
+++ b/themes/doom-dark+-theme.el
@@ -203,11 +203,11 @@ Can be an integer to determine the exact padding."
    (rjsx-attr :foreground cyan :slant 'italic :weight 'medium)
    ;;;; tab-bar/tab-line
    (tab-bar :background bg-alt :foreground (if doom-dark+-alternative-tabs fg bg-alt))
-   (tab-bar-tab :background (if doom-dark+-alternative-tabs dark-violet bg) :foreground fg :weight (when doom-dark+-alternative-tabs 'bold) :height (when doom-dark+-alternative-tabs 1.0))
+   (tab-bar-tab :background (if (and doom-dark+-blue-modeline doom-dark+-alternative-tabs) base6 (if doom-dark+-alternative-tabs dark-violet bg)) :foreground fg :weight (when doom-dark+-alternative-tabs 'bold) :height (when doom-dark+-alternative-tabs 1.0))
    (tab-bar-tab-inactive :background bg-alt :foreground fg-alt :height (when doom-dark+-alternative-tabs 1.0))
    (tab-line :background bg-alt :foreground (if doom-dark+-alternative-tabs fg bg-alt))
    (tab-line-tab :background (if doom-dark+-alternative-tabs bg-alt bg) :foreground fg :height (when doom-dark+-alternative-tabs 0.9))
-   (tab-line-tab-current :background (if doom-dark+-alternative-tabs dark-violet bg) :foreground fg :weight (when doom-dark+-alternative-tabs 'bold) :height (when doom-dark+-alternative-tabs 0.9))
+   (tab-line-tab-current :background (if (and doom-dark+-blue-modeline doom-dark+-alternative-tabs) base6 (if doom-dark+-alternative-tabs dark-violet bg)) :foreground fg :weight (when doom-dark+-alternative-tabs 'bold) :height (when doom-dark+-alternative-tabs 0.9))
    (tab-line-tab-inactive :background bg-alt :foreground fg-alt :height (when doom-dark+-alternative-tabs 0.9))
    (tab-line-tab-modified :foreground (when doom-dark+-alternative-tabs red) :height (when doom-dark+-alternative-tabs 0.9) :inherit (unless doom-dark+-alternative-tabs 'font-lock-doc-face))
    (tab-line-tab-special :weight (if doom-dark+-alternative-tabs 'unspecified 'bold) :slant (when doom-dark+-alternative-tabs 'italic) :height (when doom-dark+-alternative-tabs 0.9))

--- a/themes/doom-dark+-theme.el
+++ b/themes/doom-dark+-theme.el
@@ -29,6 +29,18 @@ Can be an integer to determine the exact padding."
   :group 'doom-dark+-theme
   :type '(choice integer boolean))
 
+(defcustom doom-dark+-alternative-tabs nil
+  "If non-nil, the following changes will happen:
+- Tab-bars and tab-lines will have the same background as the mode-line.
+- Tab-bars will have a height of 1.0.
+- Active tab-bars will have bold weight.
+- Tab-lines will have a height of 0.9.
+- Active tab-lines will have bold weight.
+- Modified tab-lines will have a contrasting foreground color.
+- Special tab-lines will have an italic slant."
+  :group 'doom-dark+-theme
+  :type '(choice integer boolean))
+
 
 ;;
 ;;; Theme definition
@@ -189,6 +201,16 @@ Can be an integer to determine the exact padding."
    ;;;; rjsx-mode
    (rjsx-tag :foreground blue)
    (rjsx-attr :foreground cyan :slant 'italic :weight 'medium)
+   ;;;; tab-bar/tab-line
+   (tab-bar :background bg-alt :foreground (if doom-dark+-alternative-tabs fg bg-alt))
+   (tab-bar-tab :background (if doom-dark+-alternative-tabs dark-violet bg) :foreground fg :weight (when doom-dark+-alternative-tabs 'bold) :height (when doom-dark+-alternative-tabs 1.0))
+   (tab-bar-tab-inactive :background bg-alt :foreground fg-alt :height (when doom-dark+-alternative-tabs 1.0))
+   (tab-line :background bg-alt :foreground (if doom-dark+-alternative-tabs fg bg-alt))
+   (tab-line-tab :background (if doom-dark+-alternative-tabs bg-alt bg) :foreground fg :height (when doom-dark+-alternative-tabs 0.9))
+   (tab-line-tab-current :background (if doom-dark+-alternative-tabs dark-violet bg) :foreground fg :weight (when doom-dark+-alternative-tabs 'bold) :height (when doom-dark+-alternative-tabs 0.9))
+   (tab-line-tab-inactive :background bg-alt :foreground fg-alt :height (when doom-dark+-alternative-tabs 0.9))
+   (tab-line-tab-modified :foreground (when doom-dark+-alternative-tabs red) :height (when doom-dark+-alternative-tabs 0.9) :inherit (unless doom-dark+-alternative-tabs 'font-lock-doc-face))
+   (tab-line-tab-special :weight (if doom-dark+-alternative-tabs 'unspecified 'bold) :slant (when doom-dark+-alternative-tabs 'italic) :height (when doom-dark+-alternative-tabs 0.9))
    ;;;; tooltip
    (tooltip :background base2 :foreground fg)
    ;;;; treemacs

--- a/themes/doom-dark+-theme.el
+++ b/themes/doom-dark+-theme.el
@@ -209,7 +209,7 @@ Can be an integer to determine the exact padding."
    (tab-line-tab :background (if doom-dark+-alternative-tabs bg-alt bg) :foreground fg :height (when doom-dark+-alternative-tabs 0.9))
    (tab-line-tab-current :background (if (and doom-dark+-blue-modeline doom-dark+-alternative-tabs) base6 (if doom-dark+-alternative-tabs dark-violet bg)) :foreground fg :weight (when doom-dark+-alternative-tabs 'bold) :height (when doom-dark+-alternative-tabs 0.9))
    (tab-line-tab-inactive :background bg-alt :foreground fg-alt :height (when doom-dark+-alternative-tabs 0.9))
-   (tab-line-tab-modified :foreground (when doom-dark+-alternative-tabs red) :height (when doom-dark+-alternative-tabs 0.9) :inherit (unless doom-dark+-alternative-tabs 'font-lock-doc-face))
+   (tab-line-tab-modified :foreground (when doom-dark+-alternative-tabs orange) :height (when doom-dark+-alternative-tabs 0.9) :inherit (unless doom-dark+-alternative-tabs 'font-lock-doc-face))
    (tab-line-tab-special :weight (if doom-dark+-alternative-tabs 'unspecified 'bold) :slant (when doom-dark+-alternative-tabs 'italic) :height (when doom-dark+-alternative-tabs 0.9))
    ;;;; tooltip
    (tooltip :background base2 :foreground fg)


### PR DESCRIPTION
Hello.

I added to `doom-dark+.el` both a section to configure tab-bar and tab-line faces, and a variable `doom-dark+-alternative-tabs` to activate the changes when non-nil, akin to `doom-dark+-blue-modeline`.

The objetive of this change is to both prettify tabs and add some contrasting with the background to make them distinguishable. Also, by making `doom-dark+-alternative-tabs` a flag we let the users decide which tabs they prefer.

Here is the comparison:

<img width="1920" height="1014" alt="original_current_unmodified" src="https://github.com/user-attachments/assets/475a9e96-6fca-4e66-a631-bb4fd5755533" />

* This is the original look of the tab-bar and tab-line. The current tab-line is unmodified.

<img width="1920" height="1015" alt="original_current_modified" src="https://github.com/user-attachments/assets/4fb8e610-c781-4f8b-af74-b6a907537c75" />

* And this is the original look with the current tab-line when buffer is modified.

<img width="1920" height="1015" alt="new_current_unmodified" src="https://github.com/user-attachments/assets/45f1d510-a756-4d41-b5f3-6270c3eb0944" />

* This is the new look of tab-bar and tab-line after setting t to `doom-dark+-alternative-tabs`. The current tab-line is unmodified.

<img width="1920" height="1015" alt="new_current_modified" src="https://github.com/user-attachments/assets/c61ae2f3-140b-4d10-a3b1-b494ee5af97f" />

* And this is the new look of the current tab-line once buffer is modified.

\
And here is a summary of the changes as described on`doom-dark+-alternative-tabs`: 
- Tab-bars and tab-lines will have the same background as the mode-line.
- Tab-bars will have a height of 1.0.
- Active tab-bars will have bold weight.
- Tab-lines will have a height of 0.9.
- Active tab-lines will have bold weight.
- Modified tab-lines will have a contrasting foreground color.
- Special tab-lines will have an italic slant.

If you like the changes, I can also port this code to the other themes.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.
