### PR TITLE
fix(base): set tab-line foreground

### DIFF
--- a/doom-themes-base.el
+++ b/doom-themes-base.el
@@ -68,7 +68,7 @@
     (header-line :inherit 'mode-line)
     (header-line-highlight :inherit 'mode-line-highlight)
     ;;;; tab-line/tab-bar (Emacs 27+)
-    (tab-line :background bg-alt :foreground bg-alt)
+    (tab-line :background bg-alt :foreground fg-alt)
     (tab-line-tab :background bg :foreground fg)
     (tab-line-tab-inactive :background bg-alt :foreground fg-alt)
     ((tab-line-tab-inactive-alternate &inherit tab-line-tab-inactive))


### PR DESCRIPTION
Fixes #720: when adding the tab-bar-format-global function to the tab-bar-format list, the global mode string should be visible in the tab bar.

The problem is obvious - both bg and fg of `tab-line` are set to `bg-alt`. Looks like a long unnoticed typo.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.